### PR TITLE
Add typed debug and strong assertions

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,0 +1,19 @@
+name: integration-pilot
+on:
+  pull_request:
+  push:
+    branches: [develop, 'codex/assert-foundation', 'codex/execution-foundation']
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # GCC 13 crashes while emitting DWARF for the stable GeoFrame templates
+        compiler: [g++-14, clang++]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y libeigen3-dev g++-14
+      - run: cmake -S tests -B build/integration -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+      - run: cmake --build build/integration --parallel 2
+      - run: ctest --test-dir build/integration --output-on-failure

--- a/fdaPDE/src/assembly.h
+++ b/fdaPDE/src/assembly.h
@@ -75,7 +75,8 @@ constexpr auto scalar_or_kth_component_of(const T& t, std::size_t k) {
     if constexpr (std::is_floating_point_v<T>) {
         return t;
     } else {
-        fdapde_constexpr_assert(std::cmp_less(k FDAPDE_COMMA t.size()));
+        fdapde_assert(
+          std::cmp_less(k FDAPDE_COMMA t.size()), std::out_of_range, "assembly coefficient index out of range");
         return t[k];
     }
 }
@@ -95,7 +96,8 @@ struct assembly_add_op : public assembly_xpr_base<assembly_add_op<Lhs, Rhs>> {
       CANNOT_SUM_ASSEMBLY_LOOPS_OF_USING_DIFFERENT_DISCRETIZATION_CATEGORIES);
     using OutputType = decltype(std::declval<Lhs>().assemble());
     assembly_add_op(const Lhs& lhs, const Rhs& rhs) : lhs_(lhs), rhs_(rhs) {
-        fdapde_assert(lhs.rows() == rhs.rows() && lhs.cols() == rhs.cols());
+        fdapde_assert(lhs.rows() == rhs.rows(), std::invalid_argument, "operand row counts must match");
+        fdapde_assert(lhs.cols() == rhs.cols(), std::invalid_argument, "operand column counts must match");
     }
     OutputType assemble() const {
         if constexpr (std::is_same_v<OutputType, Eigen::SparseMatrix<double>>) {
@@ -302,9 +304,9 @@ struct CellDiameter :
     static constexpr int XprBits = 0 | int(geo_assembler_flags::compute_geo_id);
 
     constexpr CellDiameter() noexcept : triangulation_(nullptr) { }
-    constexpr CellDiameter(const Triangulation_& triangulation) noexcept :
-        triangulation_(std::addressof(triangulation)) {
-        fdapde_assert(triangulation_->n_nodes() != 0 && triangulation_->n_cells() != 0);
+    constexpr CellDiameter(const Triangulation_& triangulation) : triangulation_(std::addressof(triangulation)) {
+        fdapde_assert(triangulation_->n_nodes() != 0, std::invalid_argument, "triangulation must contain nodes");
+        fdapde_assert(triangulation_->n_cells() != 0, std::invalid_argument, "triangulation must contain cells");
     }
     // assembly evaluation
     constexpr Scalar operator()(const InputType& geo_packet) const {
@@ -329,9 +331,9 @@ struct FaceNormal :
     static constexpr int XprBits = 0 | int(geo_assembler_flags::compute_face_normal);
 
     constexpr FaceNormal() noexcept : triangulation_(nullptr) { }
-    constexpr FaceNormal(const Triangulation_& triangulation) noexcept :
-        triangulation_(std::addressof(triangulation)) {
-        fdapde_assert(triangulation_->n_nodes() != 0 && triangulation_->n_cells() != 0);
+    constexpr FaceNormal(const Triangulation_& triangulation) : triangulation_(std::addressof(triangulation)) {
+        fdapde_assert(triangulation_->n_nodes() != 0, std::invalid_argument, "triangulation must contain nodes");
+        fdapde_assert(triangulation_->n_cells() != 0, std::invalid_argument, "triangulation must contain cells");
     }
     // assembly evaluation
     constexpr Eigen::Matrix<double, Rows, Cols> operator()(const InputType& geo_packet) const {

--- a/fdaPDE/src/fields/divergence.h
+++ b/fdaPDE/src/fields/divergence.h
@@ -42,7 +42,9 @@ class Divergence : public ScalarFieldBase<Derived_::StaticInputSize, Divergence<
 
     explicit constexpr Divergence(const Derived_& xpr) : Base(), data_(), xpr_(xpr) {
         if constexpr (StaticInputSize == Dynamic) {
-            fdapde_constexpr_assert(xpr_.input_size() == xpr_.rows());
+            fdapde_assert(
+              xpr_.input_size() == xpr_.rows(), std::invalid_argument,
+              "divergence requires one field component per input dimension");
             data_.resize(xpr_.rows());
         }
         for (int i = 0; i < xpr_.rows(); ++i) { data_[i] = FunctorType(xpr_[i], i); }

--- a/fdaPDE/src/fields/dot.h
+++ b/fdaPDE/src/fields/dot.h
@@ -52,13 +52,12 @@ class DotProduct : public ScalarFieldBase<Lhs::StaticInputSize, DotProduct<Lhs, 
 
     constexpr DotProduct(const Lhs& lhs, const Rhs& rhs) : lhs_(lhs), rhs_(rhs) {
         if constexpr (LhsDerived::Cols == Dynamic || RhsDerived::Cols == Dynamic) {
-            fdapde_assert(
-              lhs.cols() == rhs.cols() &&
-              (rhs.rows() == rhs.rows() || (lhs.cols() == 1 && rhs.rows() == 1 && lhs.rows() == rhs.cols()) ||
-               (lhs.rows() == 1 && rhs.cols() == 1 && lhs.cols() == rhs.rows())));
+            fdapde_assert(lhs.cols() == rhs.cols(), std::invalid_argument, "dot product column counts must match");
+            fdapde_assert(lhs.rows() == rhs.rows(), std::invalid_argument, "dot product row counts must match");
         }
         if constexpr (LhsDerived::StaticInputSize == Dynamic || RhsDerived::StaticInputSize == Dynamic) {
-            fdapde_assert(lhs.input_size() == rhs.input_size());
+            fdapde_assert(
+              lhs.input_size() == rhs.input_size(), std::invalid_argument, "operand input dimensions must match");
         }
     }
     constexpr Scalar operator()(const InputType& p) const {
@@ -143,10 +142,12 @@ class dot_product_eigen_impl : public ScalarFieldBase<FieldType_::StaticInputSiz
           FieldType::Cols == Dynamic || EigenType::ColsAtCompileTime == Dynamic || FieldType::Rows == Dynamic ||
           EigenType::RowsAtCompileTime == Dynamic) {
             fdapde_assert(
-              (lhs.cols() == 1 &&
-               ((rhs.cols() == 1 && lhs.rows() == rhs.rows()) || (rhs.rows() == 1 && lhs.rows() == rhs.cols()))) ||
-              (lhs.rows() == 1 &&
-               ((rhs.rows() == 1 && lhs.cols() == rhs.cols()) || (rhs.cols() == 1 && lhs.cols() == rhs.rows()))));
+              lhs.cols() == 1 || lhs.rows() == 1, std::invalid_argument, "left dot product operand must be a vector");
+            fdapde_assert(
+              rhs.cols() == 1 || rhs.rows() == 1, std::invalid_argument, "right dot product operand must be a vector");
+            fdapde_assert(
+              (lhs.cols() == 1 ? lhs.rows() : lhs.cols()) == (rhs.cols() == 1 ? rhs.rows() : rhs.cols()),
+              std::invalid_argument, "dot product vector lengths must match");
         }
     }
     Scalar operator()(const InputType& p) const {

--- a/fdaPDE/src/fields/matrix_field.h
+++ b/fdaPDE/src/fields/matrix_field.h
@@ -59,7 +59,9 @@ class MatrixFieldProduct : public MatrixFieldBase<Lhs::StaticInputSize, MatrixFi
     }
     MatrixFieldProduct(const Lhs& lhs, const Rhs& rhs) requires(Rows == Dynamic || Cols == Dynamic)
         : Base(), lhs_(lhs), rhs_(rhs) {
-        fdapde_assert(lhs_.cols() == rhs_.rows() && lhs_.input_size() == rhs_.input_size());
+        fdapde_assert(lhs_.cols() == rhs_.rows(), std::invalid_argument, "matrix product inner dimensions must match");
+        fdapde_assert(
+          lhs_.input_size() == rhs_.input_size(), std::invalid_argument, "operand input dimensions must match");
     }
     constexpr int rows() const { return lhs_.rows(); }
     constexpr int cols() const { return rhs_.cols(); }
@@ -176,26 +178,30 @@ class MatrixFieldBlock :
         block_rows_(BlockRows_ == 1 ? 1 : xpr.rows()),
         block_cols_(BlockCols_ == 1 ? 1 : xpr.cols()) {
         fdapde_static_assert(BlockRows_ == 1 || BlockCols_ == 1, THIS_METHOD_IS_ONLY_FOR_ROW_AND_COLUMN_BLOCKS);
-        fdapde_constexpr_assert(
-          i >= 0 && ((BlockRows_ == 1 && i < xpr_.rows()) || (BlockCols_ == 1 && i < xpr_.cols())));
+        fdapde_assert(i >= 0, std::out_of_range, "block index must be nonnegative");
+        fdapde_assert(
+          ((BlockRows_ == 1 && i < xpr_.rows()) || (BlockCols_ == 1 && i < xpr_.cols())), std::out_of_range,
+          "block index out of range");
     }
     constexpr MatrixFieldBlock(const Derived& xpr, int start_row, int start_col) :
         Base(), xpr_(xpr), start_row_(start_row), start_col_(start_col), block_rows_(BlockRows_),
         block_cols_(BlockCols_) {
         fdapde_static_assert(
           BlockRows_ != Dynamic && BlockCols_ != Dynamic, THIS_METHOD_IS_ONLY_FOR_STATIC_SIZED_BLOCKS);
-        fdapde_constexpr_assert(
-          start_row_ >= 0 && start_row_ + BlockRows_ <= xpr_.rows() && start_col_ >= 0 &&
-          start_col_ + BlockCols_ <= xpr_.cols());
+        fdapde_assert(start_row_ >= 0, std::out_of_range, "block starting row must be nonnegative");
+        fdapde_assert(start_row_ + BlockRows_ <= xpr_.rows(), std::out_of_range, "block exceeds the available rows");
+        fdapde_assert(start_col_ >= 0, std::out_of_range, "block starting column must be nonnegative");
+        fdapde_assert(start_col_ + BlockCols_ <= xpr_.cols(), std::out_of_range, "block exceeds the available columns");
     }
     MatrixFieldBlock(const Derived& xpr, int start_row, int start_col, int block_rows, int block_cols) :
         Base(), xpr_(xpr), start_row_(start_row), start_col_(start_col), block_rows_(block_rows),
         block_cols_(block_cols) {
         fdapde_static_assert(
           BlockRows_ == Dynamic || BlockCols_ == Dynamic, THIS_METHOD_IS_ONLY_FOR_DYNAMIC_SIZED_BLOCKS);
-        fdapde_assert(
-          start_row_ >= 0 && start_row_ + block_rows <= xpr_.rows() && start_col_ >= 0 &&
-          start_col_ + block_cols <= xpr_.cols());
+        fdapde_assert(start_row_ >= 0, std::out_of_range, "block starting row must be nonnegative");
+        fdapde_assert(start_row_ + block_rows <= xpr_.rows(), std::out_of_range, "block exceeds the available rows");
+        fdapde_assert(start_col_ >= 0, std::out_of_range, "block starting column must be nonnegative");
+        fdapde_assert(start_col_ + block_cols <= xpr_.cols(), std::out_of_range, "block exceeds the available columns");
     }
 
     constexpr int rows() const { return block_rows_; }
@@ -239,7 +245,8 @@ class MatrixFieldBlock :
         fdapde_static_assert(
           std::is_convertible_v<typename RhsDerived::FunctorType FDAPDE_COMMA typename Derived::FunctorType>,
           YOU_ARE_TRYING_TO_ASSIGN_A_BLOCK_WITH_NON_CONVERTIBLE_COEFFICIENT_TYPE);
-        fdapde_assert(rhs.rows() == xpr_.rows() && rhs.cols() == xpr_.cols());
+        fdapde_assert(rhs.rows() == xpr_.rows(), std::invalid_argument, "operand row counts must match");
+        fdapde_assert(rhs.cols() == xpr_.cols(), std::invalid_argument, "operand column counts must match");
         for (int i = 0; i < xpr_.rows(); ++i) {
             for (int j = 0; j < xpr_.cols(); ++j) { xpr_(start_row_ + i, start_col_ + j) = rhs(i, j); }
         }
@@ -291,8 +298,11 @@ class MatrixFieldBinOp : public MatrixFieldBase<Lhs::StaticInputSize, MatrixFiel
         requires(StaticInputSize == Dynamic || Rows == Dynamic || Cols == Dynamic)
         : lhs_(lhs), rhs_(rhs), op_(op) {
         fdapde_assert(
-          (lhs.input_size() == rhs.input_size()) && (Rows != Dynamic || lhs.rows() == rhs.rows()) &&
-          (Cols != Dynamic || lhs.cols() == rhs.cols()));
+          lhs.input_size() == rhs.input_size(), std::invalid_argument, "operand input dimensions must match");
+        fdapde_assert(
+          Rows != Dynamic || lhs.rows() == rhs.rows(), std::invalid_argument, "operand row counts must match");
+        fdapde_assert(
+          Cols != Dynamic || lhs.cols() == rhs.cols(), std::invalid_argument, "operand column counts must match");
     }
     MatrixFieldBinOp(const Lhs& lhs, const Rhs& rhs) : MatrixFieldBinOp(lhs, rhs, BinaryOperation {}) { }
 
@@ -534,7 +544,8 @@ class MatrixField :
         : Base(), data_(), inner_size_(0), n_rows_(0), n_cols_(0) { }
     MatrixField(int inner_size, int rows, int cols) requires(is_dynamic_sized<This>::value)
         : Base(), inner_size_(inner_size), n_rows_(rows), n_cols_(cols) {
-        fdapde_assert(rows > 0 && cols > 0);
+        fdapde_assert(rows > 0, std::invalid_argument, "row count must be positive");
+        fdapde_assert(cols > 0, std::invalid_argument, "column count must be positive");
         data_.resize(rows * cols);
     }
     // vector constructor
@@ -560,7 +571,8 @@ class MatrixField :
         fdapde_static_assert(
           StaticInputSize == Size_ && std::is_convertible_v<typename RhsDerived::FunctorType FDAPDE_COMMA FunctorType>,
           INVALID_INPUT_SIZE_OR_NON_CONVERTIBLE_FUNCTOR_TYPE);
-	fdapde_assert(rows() == other.rows() && cols() == other.cols());
+        fdapde_assert(rows() == other.rows(), std::invalid_argument, "operand row counts must match");
+        fdapde_assert(cols() == other.cols(), std::invalid_argument, "operand column counts must match");
         for (int i = 0; i < n_rows_; ++i) {
             for (int j = 0; j < n_cols_; ++j) { operator()(i, j) = other(i, j); }
         }
@@ -601,7 +613,9 @@ class MatrixField :
 
     void resize(int inner_size, int rows, int cols) {
         fdapde_static_assert(Rows == Dynamic || Cols == Dynamic, THIS_METHOD_IS_ONLY_FOR_DYNAMIC_SIZED_MATRICES);
-        fdapde_assert(inner_size > 0 && rows > 0 && cols > 0);
+        fdapde_assert(inner_size > 0, std::invalid_argument, "input dimension must be positive");
+        fdapde_assert(rows > 0, std::invalid_argument, "row count must be positive");
+        fdapde_assert(cols > 0, std::invalid_argument, "column count must be positive");
         if constexpr (Rows == Dynamic) n_rows_ = rows;
         if constexpr (Cols == Dynamic) n_cols_ = cols;
         data_ = std::vector<FunctorType>(n_rows_ * n_cols_);
@@ -612,7 +626,8 @@ class MatrixField :
         fdapde_static_assert(
           (Rows == Dynamic && Cols == 1) || (Cols == Dynamic && Rows == 1),
           THIS_METHOD_IS_ONLY_FOR_DYNAMIC_SIZED_VECTORS);
-        fdapde_assert(inner_size > 0 && size > 0);
+        fdapde_assert(inner_size > 0, std::invalid_argument, "input dimension must be positive");
+        fdapde_assert(size > 0, std::invalid_argument, "vector size must be positive");
         if constexpr (Rows == Dynamic) n_rows_ = size;
         n_cols_ = 1;
         data_ = std::vector<FunctorType>(n_rows_ * n_cols_);
@@ -621,12 +636,20 @@ class MatrixField :
     }
     // getters
     constexpr Scalar eval(int i, int j, const InputType& p) const {
-        if constexpr (is_dynamic_sized<This>::value) { fdapde_assert(p.size() == inner_size_); }
+        if constexpr (is_dynamic_sized<This>::value) {
+            fdapde_assert(
+              p.size() == inner_size_, std::invalid_argument,
+              "evaluation point dimension must match the field input dimension");
+        }
         return data_[i * cols() + j](p);
     }
     constexpr Scalar eval(int i, const InputType& p) const {
         fdapde_static_assert(Rows == 1 || Cols == 1, THIS_METHOD_IS_ONLY_FOR_VECTORS);
-        if constexpr (is_dynamic_sized<This>::value) { fdapde_assert(p.size() == inner_size_); }
+        if constexpr (is_dynamic_sized<This>::value) {
+            fdapde_assert(
+              p.size() == inner_size_, std::invalid_argument,
+              "evaluation point dimension must match the field input dimension");
+        }
         return data_[i](p);
     }
     constexpr const FunctorType& operator()(int i, int j) const { return data_[i * cols() + j]; }
@@ -727,7 +750,9 @@ struct MatrixFieldDiagonalBlock :
         fdapde_static_assert(
           std::is_convertible_v<typename RhsDerived::FunctorType FDAPDE_COMMA typename Derived::FunctorType>,
           YOU_ARE_TRYING_TO_ASSIGN_A_BLOCK_WITH_NON_CONVERTIBLE_COEFFICIENT_TYPE);
-        fdapde_assert(rhs.rows() == xpr_.rows() && rhs.cols() == 1);
+        fdapde_assert(
+          rhs.rows() == xpr_.rows(), std::invalid_argument, "diagonal length must match the matrix row count");
+        fdapde_assert(rhs.cols() == 1, std::invalid_argument, "diagonal coefficients must form a column vector");
         for (int i = 0; i < xpr_.rows(); ++i) { xpr_(i, i) = rhs[i]; }
         return *this;
     }
@@ -761,7 +786,7 @@ struct MatrixFieldSymmetricView :
     constexpr MatrixFieldSymmetricView(const Derived& xpr) requires(Rows != Dynamic && Cols != Dynamic)
         : Base(), xpr_(xpr) { }
     MatrixFieldSymmetricView(const Derived& xpr) requires(Rows == Dynamic || Cols == Dynamic) : Base(), xpr_(xpr) {
-        fdapde_assert(xpr_.rows() == xpr_.cols());
+        fdapde_assert(xpr_.rows() == xpr_.cols(), std::invalid_argument, "symmetric view requires a square matrix");
     }
 
     template <typename Dest> constexpr void eval_at(const InputType& p, Dest& dest) const {
@@ -826,7 +851,11 @@ template <int StaticInputSize, typename Derived> struct MatrixFieldBase {
             Derived::Cols == Dynamic ? Dynamic : InputType_::ColsAtCompileTime>,
           Matrix<typename Derived::Scalar, Derived::Rows, Derived::Cols>>;
         OutputType out;
-        if constexpr (Derived::StaticInputSize == Dynamic) { fdapde_assert(p.size() == derived().input_size()); }
+        if constexpr (Derived::StaticInputSize == Dynamic) {
+            fdapde_assert(
+              p.size() == derived().input_size(), std::invalid_argument,
+              "evaluation point dimension must match the field input dimension");
+        }
         if constexpr (
           Derived::Rows == Dynamic || Derived::Cols == Dynamic || InputType_::RowsAtCompileTime == Dynamic ||
           InputType_::ColsAtCompileTime == Dynamic) {
@@ -951,7 +980,8 @@ class matrix_field_eigen_product_impl :
         if constexpr (
           FieldType::Rows == Dynamic || FieldType::Cols == Dynamic || EigenType::RowsAtCompileTime == Dynamic ||
           EigenType::ColsAtCompileTime == Dynamic) {
-            fdapde_assert(lhs.cols() == rhs.rows());
+            fdapde_assert(
+              lhs.cols() == rhs.rows(), std::invalid_argument, "matrix product inner dimensions must match");
         }
     }
     int rows() const { return lhs_.rows(); }
@@ -1070,7 +1100,8 @@ class matrix_field_eigen_binary_op_impl :
         if constexpr (
           FieldType::Rows == Dynamic || FieldType::Cols == Dynamic || EigenType::RowsAtCompileTime == Dynamic ||
           EigenType::ColsAtCompileTime == Dynamic) {
-            fdapde_assert(lhs.rows() == rhs.rows() && lhs.cols() == rhs.cols());
+            fdapde_assert(lhs.rows() == rhs.rows(), std::invalid_argument, "operand row counts must match");
+            fdapde_assert(lhs.cols() == rhs.cols(), std::invalid_argument, "operand column counts must match");
         }
     }
     int rows() const { return lhs_.rows(); }

--- a/fdaPDE/src/fields/norm.h
+++ b/fdaPDE/src/fields/norm.h
@@ -35,7 +35,10 @@ class MatrixFieldNorm : public ScalarFieldBase<Derived_::StaticInputSize, Matrix
 
     explicit constexpr MatrixFieldNorm(const Derived& xpr) : Base(), xpr_(xpr) { }
     constexpr Scalar operator()(const InputType& p) const {
-        if constexpr (StaticInputSize == Dynamic) fdapde_assert(p.size() == xpr_.input_size());
+        if constexpr (StaticInputSize == Dynamic)
+            fdapde_assert(
+              p.size() == xpr_.input_size(), std::invalid_argument,
+              "evaluation point dimension must match the field input dimension");
         Scalar norm_ = 0;
         for (int i = 0; i < xpr_.rows(); ++i) {
             for (int j = 0; j < xpr_.cols(); ++j) {

--- a/fdaPDE/src/fields/polynomial.h
+++ b/fdaPDE/src/fields/polynomial.h
@@ -173,7 +173,9 @@ class Polynomial : public ScalarFieldBase<StaticInputSize_, Polynomial<StaticInp
     constexpr Polynomial() : coeff_vector_(), gradient_(), hessian_() { }
     template <typename CoeffVectorType>
     explicit constexpr Polynomial(const CoeffVectorType& coeff_vector) : coeff_vector_(), gradient_() {
-        fdapde_constexpr_assert(int(coeff_vector.size()) == n_monomials);
+        fdapde_assert(
+          int(coeff_vector.size()) == n_monomials, std::invalid_argument,
+          "coefficient count must match the polynomial basis size");
         for (int i = 0; i < n_monomials; ++i) { coeff_vector_[i] = coeff_vector[i]; }
         for (int i = 0; i < StaticInputSize; ++i) {
             gradient_[i] = Derivative(coeff_vector_, i);

--- a/fdaPDE/src/fields/scalar_field.h
+++ b/fdaPDE/src/fields/scalar_field.h
@@ -43,7 +43,11 @@ struct ScalarFieldUnaryOp :
         Base(), derived_(derived), op_(op) { }
     constexpr ScalarFieldUnaryOp(const Derived_& derived) : ScalarFieldUnaryOp(derived, UnaryFunctor {}) { }
     constexpr Scalar operator()(const InputType& p) const {
-        if constexpr (StaticInputSize == Dynamic) { fdapde_assert(p.rows() == Base::input_size()); }
+        if constexpr (StaticInputSize == Dynamic) {
+            fdapde_assert(
+              p.rows() == Base::input_size(), std::invalid_argument,
+              "evaluation point dimension must match the field input dimension");
+        }
         return op_(derived_(p));
     }
     constexpr int input_size() const { return derived_.input_size(); }
@@ -107,7 +111,8 @@ class ScalarFieldBinOp : public ScalarFieldBase<Lhs::StaticInputSize, ScalarFiel
 
     ScalarFieldBinOp(const Lhs& lhs, const Rhs& rhs, BinaryOperation op) requires(StaticInputSize == Dynamic) :
         Base(), lhs_(lhs), rhs_(rhs), op_(op) {
-        fdapde_assert(lhs.input_size() == rhs.input_size());
+        fdapde_assert(
+          lhs.input_size() == rhs.input_size(), std::invalid_argument, "operand input dimensions must match");
     }
     constexpr ScalarFieldBinOp(const Lhs& lhs, const Rhs& rhs, BinaryOperation op)
         requires(StaticInputSize != Dynamic)
@@ -118,7 +123,11 @@ class ScalarFieldBinOp : public ScalarFieldBase<Lhs::StaticInputSize, ScalarFiel
           std::is_same_v<LhsInputType FDAPDE_COMMA RhsInputType> ||
             internals::are_related_by_inheritance_v<LhsInputType FDAPDE_COMMA RhsInputType>,
           YOU_MIXED_SCALAR_FIELDS_WITH_INCOMPATIBLE_INPUT_TYPES);
-        if constexpr (StaticInputSize == Dynamic) { fdapde_assert(p.rows() == Base::input_size()); }
+        if constexpr (StaticInputSize == Dynamic) {
+            fdapde_assert(
+              p.rows() == Base::input_size(), std::invalid_argument,
+              "evaluation point dimension must match the field input dimension");
+        }
         return op_(lhs_(p), rhs_(p));
     }
     constexpr int input_size() const { return lhs_.input_size(); }
@@ -181,7 +190,11 @@ struct ScalarFieldCoeffOp :
     constexpr ScalarFieldCoeffOp(const Lhs_& lhs, const Rhs_& rhs) :
         ScalarFieldCoeffOp(lhs, rhs, BinaryOperation {}) { }
     constexpr Scalar operator()(const InputType& p) const {
-        if constexpr (StaticInputSize == Dynamic) { fdapde_assert(p.rows() == Base::input_size()); }
+        if constexpr (StaticInputSize == Dynamic) {
+            fdapde_assert(
+              p.rows() == Base::input_size(), std::invalid_argument,
+              "evaluation point dimension must match the field input dimension");
+        }
         if constexpr (is_coeff_lhs) {
             return op_(Scalar(lhs_), rhs_(p));
         } else {
@@ -288,8 +301,11 @@ class ScalarField : public ScalarFieldBase<Size, ScalarField<Size, FunctorType_>
         fdapde_static_assert(
           std::is_invocable_v<FunctorType FDAPDE_COMMA decltype(points.row(std::declval<int>()))>,
           INVALID_SCALAR_FIELD_INVOCATION);
-        fdapde_assert(points.rows() > 0 && points.cols() == input_size());
-	Eigen::Matrix<Scalar, Dynamic, 1> evals(points.rows());
+        fdapde_assert(points.rows() > 0, std::invalid_argument, "evaluation points must not be empty");
+        fdapde_assert(
+          points.cols() == input_size(), std::invalid_argument,
+          "evaluation point dimension must match the field input dimension");
+        Eigen::Matrix<Scalar, Dynamic, 1> evals(points.rows());
         for (int i = 0; i < points.rows(); ++i) { evals[i] = f_(points.row(i)); }
         return evals;
     }

--- a/fdaPDE/src/fields/spline.h
+++ b/fdaPDE/src/fields/spline.h
@@ -117,11 +117,15 @@ class Spline : public ScalarFieldBase<1, Spline> {
                     { knots.size() } -> std::convertible_to<std::size_t>;
                 })
     Spline(KnotsVectorType&& knots, int i, int order) : i_(i), order_(order) {
+        fdapde_assert(i >= 0, std::out_of_range, "spline index must be nonnegative");
+        fdapde_assert(order >= 0, std::invalid_argument, "spline order must be nonnegative");
         fdapde_assert(
-          i >= 0 && order >= 0 && std::cmp_greater_equal(knots.size(), order + 1) && std::cmp_less(i_, knots.size()));
+          std::cmp_greater_equal(knots.size(), order + 1), std::invalid_argument,
+          "knot count must exceed the spline order");
+        fdapde_assert(std::cmp_less(i_, knots.size()), std::out_of_range, "spline index exceeds the knot vector");
         knots_.reserve(knots.size());
         for (std::size_t i = 0; i < knots.size(); ++i) { knots_.push_back(knots[i]); }
-    };
+    }
 
     // non-recursive implementation of spline evaluation, as detailed in "Piegl, L., & Tiller, W. (2012). The NURBS
     // book. Springer Science & Business Media. Algorithm A2.4 pag 74"

--- a/fdaPDE/src/finite_elements/dof_constraints.h
+++ b/fdaPDE/src/finite_elements/dof_constraints.h
@@ -63,16 +63,21 @@ template <typename DofHandler> class DofConstraints {
     }
     template <typename SystemMatrix, typename SystemRhs>
     void enforce_constraints(SystemMatrix&& A, SystemRhs&& b) const {
-        fdapde_assert(A.rows() == b.rows());
-	enforce_constraints(A);
-	enforce_constraints(b);
+        fdapde_assert(
+          A.rows() == b.rows(), std::invalid_argument, "system matrix and right-hand side row counts must match");
+        enforce_constraints(A);
+        enforce_constraints(b);
         return;
     }
     // set dirichlet constraint type on boundary nodes with marker_id = marker
     template <typename... Callable> void set_dirichlet_constraint(int marker, Callable&&... g) {
         int n_boundary_dofs = dof_handler_->n_boundary_dofs(marker);
         fdapde_assert(
-          sizeof...(Callable) == dof_handler_->dof_multiplicity() && (marker == BoundaryAll || n_boundary_dofs > 0));
+          sizeof...(Callable) == dof_handler_->dof_multiplicity(), std::invalid_argument,
+          "boundary function count must match the degree-of-freedom multiplicity");
+        fdapde_assert(
+          marker == BoundaryAll || n_boundary_dofs > 0, std::invalid_argument,
+          "boundary marker must select at least one degree of freedom");
 
         for (typename DofHandlerType::boundary_dofs_iterator it = dof_handler_->boundary_dofs_begin(marker);
              it != dof_handler_->boundary_dofs_end(marker); ++it) {

--- a/fdaPDE/src/finite_elements/dof_handler.h
+++ b/fdaPDE/src/finite_elements/dof_handler.h
@@ -104,11 +104,21 @@ template <int LocalDim, int EmbedDim, typename Derived> class fe_dof_handler_bas
     };  
     cell_iterator cells_begin(int marker = TriangulationAll) const {
         const std::vector<int>& cells_markers = triangulation_->cells_markers();
-        fdapde_assert(marker == TriangulationAll || (marker >= 0 && cells_markers.size() != 0));
+        fdapde_assert(
+          marker == TriangulationAll || marker >= 0, std::invalid_argument,
+          "cell marker must be nonnegative or TriangulationAll");
+        fdapde_assert(
+          marker == TriangulationAll || cells_markers.size() != 0, std::logic_error,
+          "cell markers must be initialized before filtering");
         return cell_iterator(0, static_cast<const Derived*>(this), marker);
     }
     cell_iterator cells_end(int marker = TriangulationAll) const {
-        fdapde_assert(marker == TriangulationAll || (marker >= 0 && triangulation_->cells_markers().size() != 0));
+        fdapde_assert(
+          marker == TriangulationAll || marker >= 0, std::invalid_argument,
+          "cell marker must be nonnegative or TriangulationAll");
+        fdapde_assert(
+          marker == TriangulationAll || triangulation_->cells_markers().size() != 0, std::logic_error,
+          "cell markers must be initialized before filtering");
         return cell_iterator(triangulation_->n_cells(), static_cast<const Derived*>(this), marker);
     }
     class BoundaryDofType {
@@ -164,7 +174,9 @@ template <int LocalDim, int EmbedDim, typename Derived> class fe_dof_handler_bas
     }
     // dofs constaints handling
     template <typename... Data> void set_dirichlet_constraint(int on, Data&&... g) {
-        fdapde_assert(sizeof...(Data) == derived().dof_multiplicity());
+        fdapde_assert(
+          sizeof...(Data) == derived().dof_multiplicity(), std::invalid_argument,
+          "boundary function count must match the degree-of-freedom multiplicity");
         dof_constraints_.set_dirichlet_constraint(on, g...);
     }
     template <typename... Data> void set_dirichlet_constraint(const std::initializer_list<int>& on, Data&&... g) {
@@ -173,8 +185,10 @@ template <int LocalDim, int EmbedDim, typename Derived> class fe_dof_handler_bas
     template <typename Iterator, typename... Data>
         requires(std::input_iterator<Iterator>)
     void set_dirichlet_constraint(Iterator begin, Iterator end, Data&&... g) {
-        fdapde_assert(sizeof...(Data) == derived().dof_multiplicity());
-	for(auto it = begin; it != end; ++it) { dof_constraints_.set_dirichlet_constraint(*it, g...); }
+        fdapde_assert(
+          sizeof...(Data) == derived().dof_multiplicity(), std::invalid_argument,
+          "boundary function count must match the degree-of-freedom multiplicity");
+        for (auto it = begin; it != end; ++it) { dof_constraints_.set_dirichlet_constraint(*it, g...); }
     }
     template <typename... Data> void set_dirichlet_constraint(Data&&... g) {
         set_dirichlet_constraint(BoundaryAll, g...);

--- a/fdaPDE/src/finite_elements/dof_tetrahedron.h
+++ b/fdaPDE/src/finite_elements/dof_tetrahedron.h
@@ -116,11 +116,11 @@ template <typename DofHandler> class DofTetrahedron : public Tetrahedron<typenam
     }
     // overload geometric getters to return dof-informed structures
     EdgeType edge(int n) const {
-        fdapde_assert(n < Base::n_edges);
+        fdapde_assert(n < Base::n_edges, std::out_of_range, "edge index out of range");
         return EdgeType(dof_handler_->triangulation()->cell_to_edges()(Base::id(), n), dof_handler_);
     }
     FaceType face(int n) const {
-        fdapde_assert(n < Base::n_faces);
+        fdapde_assert(n < Base::n_faces, std::out_of_range, "face index out of range");
         return FaceType(dof_handler_->triangulation()->cell_to_faces()(Base::id(), n), dof_handler_);
     }
     // iterator over tetrahedron edges

--- a/fdaPDE/src/finite_elements/dof_triangle.h
+++ b/fdaPDE/src/finite_elements/dof_triangle.h
@@ -82,7 +82,7 @@ class DofTriangle : public Triangle<typename DofHandler::TriangulationType> {
     }
     // overload geometric edge getter to return dof-informed edge structure
     EdgeType edge(int n) const {
-        fdapde_assert(n < Base::n_edges);
+        fdapde_assert(n < Base::n_edges, std::out_of_range, "edge index out of range");
         return EdgeType(dof_handler_->triangulation()->cell_to_edges()(Base::id(), n), dof_handler_);
     }
     class edge_iterator : public internals::index_iterator<edge_iterator, EdgeType> {

--- a/fdaPDE/src/finite_elements/fe_assembler_base.h
+++ b/fdaPDE/src/finite_elements/fe_assembler_base.h
@@ -165,7 +165,8 @@ struct fe_assembler_base {
         test_space_(&internals::test_space(form_)),
         begin_(begin),
         end_(end) {
-        fdapde_assert(dof_handler_->n_dofs() > 0);
+        fdapde_assert(
+          dof_handler_->n_dofs() > 0, std::logic_error, "degrees of freedom must be initialized before assembly");
     }
     const TestSpace& test_space() const { return *test_space_; }
    protected:
@@ -322,7 +323,9 @@ struct fe_assembler_base {
         constexpr int n_basis_ = GradMdArray::static_extents[0];
         constexpr int n_quadrature_nodes_ = GradMdArray::static_extents[1];
         constexpr int n_components_ = GradMdArray::static_extents[2];
-        fdapde_constexpr_assert(n_components_ == 1 || n_components_ == local_dim);
+        fdapde_assert(
+          n_components_ == 1 || n_components_ == local_dim, std::invalid_argument,
+          "gradient component count must be one or match the local dimension");
         for (int i = 0; i < n_basis_; ++i) {
             for (int j = 0; j < n_quadrature_nodes_; ++j) {
                 // get i-th reference basis gradient evaluted at j-th quadrature node

--- a/fdaPDE/src/finite_elements/fe_bilinear_form_assembler.h
+++ b/fdaPDE/src/finite_elements/fe_bilinear_form_assembler.h
@@ -94,7 +94,12 @@ class fe_bilinear_form_assembly_loop :
         requires(sizeof...(quadrature) <= 1)
         : Base(form, begin, end, quadrature...), trial_space_(&internals::trial_space(form_)) {
         if constexpr (is_petrov_galerkin) { trial_dof_handler_ = &internals::trial_space(form_).dof_handler(); }
-        fdapde_assert(test_dof_handler()->n_dofs() != 0 && trial_dof_handler()->n_dofs() != 0);
+        fdapde_assert(
+          test_dof_handler()->n_dofs() != 0, std::logic_error,
+          "test degrees of freedom must be initialized before assembly");
+        fdapde_assert(
+          trial_dof_handler()->n_dofs() != 0, std::logic_error,
+          "trial degrees of freedom must be initialized before assembly");
     }
 
     Eigen::SparseMatrix<double> assemble() const {

--- a/fdaPDE/src/finite_elements/fe_evaluator.h
+++ b/fdaPDE/src/finite_elements/fe_evaluator.h
@@ -50,7 +50,12 @@ template <typename Form_> struct fe_pointwise_evaluator_loop {
         dof_handler_(&internals::test_space(form_).dof_handler()),
         fe_space_(&internals::test_space(form_)),
         locs_(locs) {
-        fdapde_assert(dof_handler_->n_dofs() > 0 && locs.rows() > 0 && locs.cols() == embed_dim);
+        fdapde_assert(
+          dof_handler_->n_dofs() > 0, std::logic_error, "degrees of freedom must be initialized before evaluation");
+        fdapde_assert(locs.rows() > 0, std::invalid_argument, "evaluation points must not be empty");
+        fdapde_assert(
+          locs.cols() == embed_dim, std::invalid_argument,
+          "evaluation point dimension must match the embedding dimension");
         cell_ids_ = fe_space_->triangulation().locate(locs_);
     }
 

--- a/fdaPDE/src/finite_elements/fe_objects.h
+++ b/fdaPDE/src/finite_elements/fe_objects.h
@@ -554,7 +554,10 @@ class FeFunction :
         } else {
             fe_space_ = std::addressof(fe_space);
         }
-        fdapde_assert(coeff.size() > 0 && coeff.size() == fe_space_->n_dofs());
+        fdapde_assert(coeff.size() > 0, std::invalid_argument, "coefficient vector must not be empty");
+        fdapde_assert(
+          coeff.size() == fe_space_->n_dofs(), std::invalid_argument,
+          "coefficient count must match the number of degrees of freedom");
     }
     OutputType operator()(const InputType& p) const {
         int e_id = fe_space_->triangulation().locate(p);
@@ -671,7 +674,10 @@ class FeFunction :
     }
     // assignment from expansion coefficient vector
     FeFunction& operator=(const Eigen::Matrix<double, Dynamic, 1>& coeff) {
-        fdapde_assert(coeff.size() > 0 && coeff.size() == fe_space_->n_dofs());
+        fdapde_assert(coeff.size() > 0, std::invalid_argument, "coefficient vector must not be empty");
+        fdapde_assert(
+          coeff.size() == fe_space_->n_dofs(), std::invalid_argument,
+          "coefficient count must match the number of degrees of freedom");
         coeff_ = coeff;
         return *this;
     }

--- a/fdaPDE/src/finite_elements/fe_space.h
+++ b/fdaPDE/src/finite_elements/fe_space.h
@@ -167,9 +167,9 @@ template <typename Triangulation_, typename FeType_> class FeSpace {
 
     // access i-th basis function on physical domain
     FeFunction<FeSpace<Triangulation_, FeType_>> operator[](int i) {
-        fdapde_assert(i < dof_handler_.n_dofs());
-	Eigen::Matrix<double, Dynamic, 1> coeff = Eigen::Matrix<double, Dynamic, 1>::Zero(dof_handler_.n_dofs());
-	coeff[i] = 1;
+        fdapde_assert(i < dof_handler_.n_dofs(), std::out_of_range, "basis function index out of range");
+        Eigen::Matrix<double, Dynamic, 1> coeff = Eigen::Matrix<double, Dynamic, 1>::Zero(dof_handler_.n_dofs());
+        coeff[i] = 1;
         return FeFunction<FeSpace<Triangulation_, FeType_>>(*this, coeff);
     }
     // boundary conditions

--- a/fdaPDE/src/finite_elements/lagrange_basis.h
+++ b/fdaPDE/src/finite_elements/lagrange_basis.h
@@ -84,7 +84,7 @@ template <int Order_> struct LagrangeBasis<0, Order_> {
     }
     // getters
     constexpr PolynomialType operator[](int i) const {
-        fdapde_assert(i < size());
+        fdapde_assert(i < size(), std::out_of_range, "polynomial basis index out of range");
         return PolynomialType {};
     }
     constexpr int size() const { return 1; }

--- a/fdaPDE/src/geoframe/areal_layer.h
+++ b/fdaPDE/src/geoframe/areal_layer.h
@@ -35,13 +35,15 @@ template <typename Triangulation_> struct areal_layer {
     template <typename GeoDescriptor>
         requires(is_vector_like_v<GeoDescriptor> &&
                  std::is_convertible_v<subscript_result_of_t<GeoDescriptor, int>, int>)
-    areal_layer(Triangulation_* triangulation, const GeoDescriptor& regions) noexcept :
+    areal_layer(Triangulation_* triangulation, const GeoDescriptor& regions) :
         triangulation_(triangulation), incidence_matrix_(), n_regions_(0) {
-        fdapde_assert(std::cmp_equal(regions.size() FDAPDE_COMMA triangulation_->n_cells()));
+        fdapde_assert(
+          std::cmp_equal(regions.size() FDAPDE_COMMA triangulation_->n_cells()), std::invalid_argument,
+          "region descriptor count must match the number of cells");
         // count number of regions
         std::unordered_set<int> unique_region_ids;
         for (int i = 0, n = regions.size(); i < n; ++i) {
-            fdapde_assert(regions[i] >= 0);
+            fdapde_assert(regions[i] >= 0, std::invalid_argument, "region identifiers must be nonnegative");
             unique_region_ids.insert(regions[i]);
         }
         n_regions_ = unique_region_ids.size();
@@ -49,17 +51,21 @@ template <typename Triangulation_> struct areal_layer {
         incidence_matrix_.resize(n_regions_, triangulation_->n_cells());
         for (int i = 0, n = triangulation_->n_cells(); i < n; ++i) { incidence_matrix_.set(regions[i], i); }
     }
-    areal_layer(Triangulation* triangulation, const binary_t& incidence_matrix) noexcept :
+    areal_layer(Triangulation* triangulation, const binary_t& incidence_matrix) :
         triangulation_(triangulation), incidence_matrix_(incidence_matrix), n_regions_(incidence_matrix.rows()) {
-        fdapde_assert(incidence_matrix.cols() == triangulation_->n_cells());
+        fdapde_assert(
+          incidence_matrix.cols() == triangulation_->n_cells(), std::invalid_argument,
+          "incidence matrix column count must match the number of cells");
     }
     template <typename GeoDescriptor>
         requires(is_vector_like_v<GeoDescriptor> &&
                  std::is_same_v<
                    std::decay_t<subscript_result_of_t<GeoDescriptor, int>>, MultiPolygon<local_dim, embed_dim>>)
-    areal_layer(Triangulation_* triangulation, const GeoDescriptor& regions) noexcept :
+    areal_layer(Triangulation_* triangulation, const GeoDescriptor& regions) :
         triangulation_(triangulation), incidence_matrix_(), n_regions_(0) {
-        fdapde_assert(regions.size() == triangulation_->n_cells());
+        fdapde_assert(
+          regions.size() == triangulation_->n_cells(), std::invalid_argument,
+          "region descriptor count must match the number of cells");
         // count number of regions
         n_regions_ = regions.size();
         incidence_matrix_.resize(n_regions_, triangulation_->n_cells());
@@ -69,11 +75,13 @@ template <typename Triangulation_> struct areal_layer {
             }
 	}
     }
-    areal_layer(Triangulation_* triangulation, const std::vector<BinaryMatrix<Dynamic, 1>>& regions) noexcept :
+    areal_layer(Triangulation_* triangulation, const std::vector<BinaryMatrix<Dynamic, 1>>& regions) :
         triangulation_(triangulation), incidence_matrix_(), n_regions_(regions.size()) {
         incidence_matrix_.resize(n_regions_, triangulation_->n_cells());
         for (int i = 0; i < n_regions_; ++i) {
-            fdapde_assert(regions[i].rows() == triangulation_->n_cells());
+            fdapde_assert(
+              regions[i].rows() == triangulation_->n_cells(), std::invalid_argument,
+              "region mask size must match the number of cells");
             for (int j = 0, n = triangulation_->n_cells(); j < n; ++j) {
                 if (regions[i][j]) incidence_matrix_.set(i, j);
             }
@@ -84,7 +92,7 @@ template <typename Triangulation_> struct areal_layer {
     int rows() const { return n_regions_; }
     // geometry
     BinaryVector<Dynamic> operator[](int i) const {
-        fdapde_assert(i < n_regions_);
+        fdapde_assert(i < n_regions_, std::out_of_range, "region index out of range");
         return incidence_matrix_.row(i);
     }
     Triangulation& triangulation() { return *triangulation_; }

--- a/fdaPDE/src/geoframe/data_layer.h
+++ b/fdaPDE/src/geoframe/data_layer.h
@@ -164,13 +164,15 @@ template <typename Scalar_, typename DataObj> struct plain_col_view {
     plain_col_view& operator=(Src&& src) {
         // inplace assignment
         if constexpr (is_vector_like_v<Src> && !is_indexable_v<Src, Order, index_t>) {
-            fdapde_assert(src.size() == rows_);
+            fdapde_assert(
+              src.size() == rows_, std::invalid_argument, "source row count must match the destination column");
             if (blk_sz_ == 1) {   // vector - vector assign
                 block_.assign_inplace_from(src);
                 return *this;
             }
         } else {
-            fdapde_assert(src.rows() == rows_);
+            fdapde_assert(
+              src.rows() == rows_, std::invalid_argument, "source row count must match the destination column");
             if (blk_sz_ == src.cols()) {   // block - block asssign
                 block_.assign_inplace_from(src);
                 return *this;
@@ -388,9 +390,12 @@ template <typename DataLayer> struct random_access_row_view {
     random_access_row_view() noexcept = default;
     template <typename Iterator>
     random_access_row_view(DataLayer* data, Iterator begin, Iterator end) : data_(data), idxs_(begin, end) {
+        fdapde_assert(*begin >= 0, std::out_of_range, "first row index must be nonnegative");
         fdapde_assert(
-          *begin >= 0 && std::cmp_less(*begin FDAPDE_COMMA data->rows()) && *(end - 1) >= *begin &&
-          std::cmp_less(*(end - 1) FDAPDE_COMMA data->rows()));
+          std::cmp_less(*begin FDAPDE_COMMA data->rows()), std::out_of_range, "first row index out of range");
+        fdapde_assert(*(end - 1) >= *begin, std::out_of_range, "last row index must not precede the first");
+        fdapde_assert(
+          std::cmp_less(*(end - 1) FDAPDE_COMMA data->rows()), std::out_of_range, "last row index out of range");
     }
     template <typename Filter>
         requires(requires(Filter f, index_t i) {
@@ -407,7 +412,8 @@ template <typename DataLayer> struct random_access_row_view {
             { vec[i] } -> std::convertible_to<bool>;
         })
     random_access_row_view(DataLayer* data, const LogicalVec& vec) : data_(data) {
-        fdapde_assert(vec.size() == data_->rows());
+        fdapde_assert(
+          vec.size() == data_->rows(), std::invalid_argument, "row filter size must match the data row count");
         for (size_t i = 0, n = vec.size(); i < n; ++i) {
             if (vec[i]) { idxs_.push_back(i); }
         }
@@ -421,11 +427,11 @@ template <typename DataLayer> struct random_access_row_view {
     std::vector<std::string> colnames() const { return data_->colnames(); }
     // accessors
     plain_row_view<DataLayer> operator[](index_t i) {
-        fdapde_assert(i < idxs_.size());
+        fdapde_assert(i < idxs_.size(), std::out_of_range, "selected row index out of range");
         return data_->row(idxs_[i]);
     }
     plain_row_view<const DataLayer> operator[](index_t i) const {
-        fdapde_assert(i < idxs_.size());
+        fdapde_assert(i < idxs_.size(), std::out_of_range, "selected row index out of range");
         return data_->row(idxs_[i]);
     }
     template <typename T> random_access_col_view<T, DataLayer> col(const std::string& colname) {
@@ -644,11 +650,13 @@ class scalar_data_layer {
         std::unordered_map<dtype, int> type_id_map = make_dtyped_map<int>();
         std::unordered_map<dtype, int> type_id_col = make_dtyped_map<int>();
         auto push_column_descriptor = [&, this]<typename T>(const std::string& colname, const T& t) mutable {
-            fdapde_assert(!has_column_(colname) && colname.size() != 0);
+            fdapde_assert(!has_column_(colname), std::invalid_argument, "column name already exists");
+            fdapde_assert(colname.size() != 0, std::invalid_argument, "column name must not be empty");
             if (rows_ == 0) {
                 rows_ = t.size();
             } else {
-                fdapde_assert(rows_ != 0 && rows_ == t.size());
+                fdapde_assert(rows_ != 0, std::logic_error, "existing columns must have a nonzero row count");
+                fdapde_assert(rows_ == t.size(), std::invalid_argument, "column lengths must match");
             }
             using MappedT = mapped_type_t<std::decay_t<decltype(std::declval<T>()[std::declval<index_t>()])>>;
             // add field descriptor
@@ -703,18 +711,22 @@ class scalar_data_layer {
           ...)
     scalar_data_layer(const std::vector<std::string>& colnames, const DataT&... data) :
         freemem_(make_dtyped_map<std::vector<bool>>()) {
-        fdapde_assert(colnames.size() == sizeof...(data));
+        fdapde_assert(
+          colnames.size() == sizeof...(data), std::invalid_argument,
+          "column name count must match the number of data vectors");
         // for each type id, the number of columns of that type
         std::unordered_map<dtype, int> type_id_map = make_dtyped_map<int>();
         std::unordered_map<dtype, int> type_id_col = make_dtyped_map<int>();
         // push column descriptors
         internals::for_each_index_and_args<sizeof...(DataT)>(
           [&]<int Ns_, typename T>(T t) {
-              fdapde_assert(!has_column_(colnames[Ns_]) && colnames[Ns_].size() != 0);
+              fdapde_assert(!has_column_(colnames[Ns_]), std::invalid_argument, "column name already exists");
+              fdapde_assert(colnames[Ns_].size() != 0, std::invalid_argument, "column name must not be empty");
               if (rows_ == 0) {
                   rows_ = t.size();
               } else {
-                  fdapde_assert(rows_ != 0 && rows_ == t.size());
+                  fdapde_assert(rows_ != 0, std::logic_error, "existing columns must have a nonzero row count");
+                  fdapde_assert(rows_ == t.size(), std::invalid_argument, "column lengths must match");
               }
               using MappedT = mapped_type_t<std::decay_t<decltype(std::declval<T>()[std::declval<index_t>()])>>;
               // add field descriptor
@@ -799,12 +811,12 @@ class scalar_data_layer {
         return has_column_(column);
     }
     logical_t nan(const std::vector<std::string>& colnames) const {
-        fdapde_assert(colnames.size() > 0);
+        fdapde_assert(colnames.size() > 0, std::invalid_argument, "column selection must not be empty");
         size_t n_rows = rows_, n_cols = 0;
 	std::vector<std::size_t> offset;
 	offset.push_back(0);
         for (const std::string& col : colnames) {
-            fdapde_assert(has_column_(col));
+            fdapde_assert(has_column_(col), std::out_of_range, "column name not found");
             offset.push_back(offset.back() + header_.at(col_idx_.at(col)).size());
         }
         logical_t nan(n_rows, n_cols);
@@ -812,7 +824,7 @@ class scalar_data_layer {
         return nan;
     }
     logical_t nan(const std::string& colname) const {
-        fdapde_assert(has_column_(colname));
+        fdapde_assert(has_column_(colname), std::out_of_range, "column name not found");
         field f = header_.at(col_idx_.at(colname));
         logical_t nan(rows_, f.size());
         extract_nan_pattern_(colname, nan, 0);
@@ -827,28 +839,28 @@ class scalar_data_layer {
     // accessors
     // column access
     template <typename T> plain_col_view<T, scalar_data_layer> col(size_t col) {
-        fdapde_assert(col < cols_);
+        fdapde_assert(col < cols_, std::out_of_range, "column index out of range");
         return plain_col_view<T, scalar_data_layer>(*this, header_[col]);
     }
     template <typename T> plain_col_view<T, const scalar_data_layer> col(size_t col) const {
-        fdapde_assert(col < cols_);
+        fdapde_assert(col < cols_, std::out_of_range, "column index out of range");
         return plain_col_view<T, const scalar_data_layer>(*this, header_[col]);
     }
     template <typename T> plain_col_view<T, scalar_data_layer> col(const std::string& colname) {
-        fdapde_assert(has_column_(colname));
+        fdapde_assert(has_column_(colname), std::out_of_range, "column name not found");
         return col<T>(col_idx_.at(colname));
     }
     template <typename T> plain_col_view<T, const scalar_data_layer> col(const std::string& colname) const {
-        fdapde_assert(has_column_(colname));
+        fdapde_assert(has_column_(colname), std::out_of_range, "column name not found");
         return col<T>(col_idx_.at(colname));
     }
     // row access
     plain_row_view<scalar_data_layer> row(size_t row) {
-        fdapde_assert(row < rows_);
+        fdapde_assert(row < rows_, std::out_of_range, "row index out of range");
         return plain_row_view<scalar_data_layer>(this, row);
     }
     plain_row_view<const scalar_data_layer> row(size_t row) const {
-        fdapde_assert(row < rows_);
+        fdapde_assert(row < rows_, std::out_of_range, "row index out of range");
         return plain_row_view<const scalar_data_layer>(this, row);
     }
     // row filtering operations
@@ -874,7 +886,9 @@ class scalar_data_layer {
     template <typename T> data_table<T>& data() { return fetch_<mapped_type_t<T>>(data_); }
     // modifiers
     void set_colnames(const std::vector<std::string>& colnames) {
-        fdapde_assert(colnames.size() == header_.size());
+        fdapde_assert(
+          colnames.size() == header_.size(), std::invalid_argument,
+          "column name count must match the number of fields");
         for (size_t i = 0; i < colnames.size(); ++i) { header_[i].set_colname(colnames[i]); }
         return;
     }
@@ -888,7 +902,9 @@ class scalar_data_layer {
             return;   // exts coincide with current size, skip resizing
         }
         data.resize(static_cast<index_t>(exts)...);   // resize storage discarding old values
-	fdapde_assert(rows_ == 0 || rows_ == data.extent(0));
+        fdapde_assert(
+          rows_ == 0 || rows_ == data.extent(0), std::invalid_argument,
+          "resized row count must match existing columns");
         rows_ = data.extent(0);
         dtype type_id = internals::dtype_from_static_type<Scalar>().type_id;
         freemem_[type_id].resize(data.extent(1));
@@ -929,8 +945,10 @@ class scalar_data_layer {
             // allocate memory
             data.resize(static_cast<index_t>(exts)...);
 	    int new_size = data.extent(1);
-            fdapde_assert(rows_ == 0 || rows_ == data.extent(0));
-            rows_ = data.extent(0);
+        fdapde_assert(
+          rows_ == 0 || rows_ == data.extent(0), std::invalid_argument,
+          "resized row count must match existing columns");
+        rows_ = data.extent(0);
 	    // flag new memory as free
             for (int i = 0; i < new_size - old_size; ++i) { freemem_[type_id].push_back(true); }
             fetch_<Scalar>(data_)
@@ -938,7 +956,9 @@ class scalar_data_layer {
               .assign_inplace_from(tmp);	    
         } else {   // nothing to copy
             data.resize(static_cast<index_t>(exts)...);   // resize storage discarding old values
-            fdapde_assert(rows_ == 0 || rows_ == data.extent(0));
+            fdapde_assert(
+              rows_ == 0 || rows_ == data.extent(0), std::invalid_argument,
+              "resized row count must match existing columns");
             rows_ = data.extent(0);
             freemem_[type_id].resize(data.extent(1));
             for (typename std::vector<bool>::reference b : freemem_[type_id]) { b = true; }
@@ -953,9 +973,11 @@ class scalar_data_layer {
           std::is_pointer_v<Src>, std::remove_pointer_t<Src>, std::decay_t<decltype(std::declval<Src>()[index_t()])>>;
         using SrcType_ = mapped_type_t<SrcType>;
         if constexpr (!std::is_pointer_v<Src>) {
-            fdapde_assert(fetch_<SrcType_>(data_).extent(0) == 0 || src.size() == fetch_<SrcType_>(data_).extent(0));
+            fdapde_assert(
+              fetch_<SrcType_>(data_).extent(0) == 0 || src.size() == fetch_<SrcType_>(data_).extent(0),
+              std::invalid_argument, "appended data row count must match existing columns");
         }
-	fdapde_assert(!has_column_(colname));
+        fdapde_assert(!has_column_(colname), std::invalid_argument, "column name already exists");
         dtype type_id = internals::dtype_from_static_type<SrcType_>().type_id;
         // check if there is already allocated free memory to hold src
         index_t offset = find_free_blk_idx_<SrcType_>(1);
@@ -990,8 +1012,10 @@ class scalar_data_layer {
         using ValueType_ =
           decltype(internals::apply_index_pack<Order>([&]<int... Ns_>() { return src(((void)Ns_, index_t())...); }));
         using SrcType_ = mapped_type_t<std::decay_t<ValueType_>>;
-        fdapde_assert(fetch_<SrcType_>(data_).extent(0) == 0 || src.rows() == fetch_<SrcType_>(data_).extent(0));
-        fdapde_assert(!has_column_(colname));
+        fdapde_assert(
+          fetch_<SrcType_>(data_).extent(0) == 0 || src.rows() == fetch_<SrcType_>(data_).extent(0),
+          std::invalid_argument, "appended data row count must match existing columns");
+        fdapde_assert(!has_column_(colname), std::invalid_argument, "column name already exists");
         dtype type_id = internals::dtype_from_static_type<SrcType_>().type_id;
         // check if there is already allocated free memory to hold src
         index_t offset = find_free_blk_idx_<SrcType_>(src.cols());
@@ -1042,7 +1066,7 @@ class scalar_data_layer {
     }
     // do not perform any memory reallocation, sets the corresponding freemem_ bits to 1 and update header
     void erase(const std::string& colname) {
-        fdapde_assert(has_column_(colname));
+        fdapde_assert(has_column_(colname), std::out_of_range, "column name not found");
         auto it = std::find_if(header_.begin(), header_.end(), [&](const field& f) { return f.colname() == colname; });
         for (int i = it->offset(); i < it->offset() + it->size(); ++i) { freemem_[it->type_id()][i] = true; }
         col_idx_.erase(colname);
@@ -1166,7 +1190,7 @@ class scalar_data_layer {
     // returns the index of the first typed memory column which can hold a **contiguous** block of blk_sz columns, or -1
     // if there is no such available (already allocated) memory
     template <typename Scalar> index_t find_free_blk_idx_(size_t blk_sz) {
-        fdapde_assert(blk_sz > 0);
+        fdapde_assert(blk_sz > 0, std::invalid_argument, "requested column block size must be positive");
         dtype type_id = dtype_from_static_type<Scalar>().type_id;
         const std::vector<bool>& freemem = freemem_[type_id];
         int j = 0;

--- a/fdaPDE/src/geoframe/geo_layer.h
+++ b/fdaPDE/src/geoframe/geo_layer.h
@@ -65,7 +65,7 @@ struct geo_col_view :
         Base(geo_data->data(), desc), row_begin_(0), geo_data_(geo_data) { }
     // observers
     auto geometry(int i) const {
-        fdapde_assert(i < rows_);
+        fdapde_assert(i < rows_, std::out_of_range, "row index out of range");
         return geo_data_->geometry(row_begin_ + i);
     }
     const GeoLayer& geo_data() const { return *geo_data_; }
@@ -114,7 +114,7 @@ struct geo_row_view :
 
     geo_row_view() noexcept = default;
     geo_row_view(GeoLayer* geo_data, int row) : Base(std::addressof(geo_data->data()), row), geo_data_(geo_data) {
-        fdapde_assert(row < geo_data_->rows());
+        fdapde_assert(row < geo_data_->rows(), std::out_of_range, "row index out of range");
     }
     // observers
     auto geometry() const { return geo_data_->geometry(this->id()); }
@@ -155,9 +155,11 @@ struct random_access_geo_row_view :
     template <typename Iterator>
     random_access_geo_row_view(GeoLayer* geo_data, Iterator begin, Iterator end) :
         Base(std::addressof(geo_data->data()), begin, end), geo_data_(geo_data) {
-        fdapde_assert(std::all_of(begin FDAPDE_COMMA end FDAPDE_COMMA [this](index_t i) {
-            return std::cmp_less(i FDAPDE_COMMA geo_data_->rows());
-        }));
+        fdapde_assert(
+          std::all_of(begin FDAPDE_COMMA end FDAPDE_COMMA[this](index_t i) {
+              return std::cmp_less(i FDAPDE_COMMA geo_data_->rows());
+          }),
+          std::out_of_range, "selected geometry row index out of range");
     }
     template <typename Filter>
         requires(requires(Filter f, index_t i) {
@@ -172,7 +174,9 @@ struct random_access_geo_row_view :
                 })
     random_access_geo_row_view(GeoLayer* geo_data, const LogicalVec& vec) :
         Base(std::addressof(geo_data->data()), vec), geo_data_(geo_data) {
-        fdapde_assert(vec.size() < geo_data_->rows());
+        fdapde_assert(
+          vec.size() < geo_data_->rows(), std::invalid_argument,
+          "geometry filter size must be smaller than the geometry row count");
     }
     // observers
     auto geometry(int i) const { return geo_data_->geometry(this->idxs_[i]); }
@@ -331,8 +335,11 @@ struct GeoLayer {
     storage_t& data() { return data_; }
     void make_structured() {
         if (Order == 1 || structured_) { return; }
-        internals::for_each_index_in_pack<Order>(
-          [&]<int Ns_>() { fdapde_assert(std::get<Ns_>(geo_data_).rows() != 0); });
+        internals::for_each_index_in_pack<Order>([&]<int Ns_>() {
+            fdapde_assert(
+              std::get<Ns_>(geo_data_).rows() != 0, std::logic_error,
+              "geometry must be initialized before making the layer structured");
+        });
 
         constexpr int full_embed_dim = std::accumulate(embed_dim.begin(), embed_dim.end(), 0);	
         using point_t = std::array<double, full_embed_dim>;
@@ -430,8 +437,9 @@ struct GeoLayer {
     // data import
     template <typename T> void load_csv(const std::vector<std::string>& colnames, const std::string& filename) {
         auto csv = read_csv<T>(filename);
-	fdapde_assert(csv.cols() == colnames.size());
-	load_table_<T>(colnames, csv);
+        fdapde_assert(
+          csv.cols() == colnames.size(), std::invalid_argument, "column name count must match the input table");
+        load_table_<T>(colnames, csv);
         return;
     }
     template <typename T> void load_csv(const std::string& filename) {
@@ -441,7 +449,8 @@ struct GeoLayer {
     }
     template <typename T> void load_txt(const std::vector<std::string>& colnames, const std::string& filename) {
         auto txt = read_txt<T>(filename);
-        fdapde_assert(txt.cols() == colnames.size());
+        fdapde_assert(
+          txt.cols() == colnames.size(), std::invalid_argument, "column name count must match the input table");
         load_table_<T>(colnames, txt);
         return;
     }
@@ -492,10 +501,14 @@ struct GeoLayer {
     template <typename... Ts>
         requires(internals::is_vector_like_v<Ts> && ...)
     void load_vec(const std::vector<std::string>& colnames, const Ts&... data) {
-        fdapde_assert(colnames.size() == sizeof...(data));
+        fdapde_assert(
+          colnames.size() == sizeof...(data), std::invalid_argument,
+          "column name count must match the number of data vectors");
         internals::for_each_index_and_args<sizeof...(data)>(
           [&, this]<int Ns_, typename Ts_>(const Ts_& ts) {
-              fdapde_assert(std::cmp_equal(ts.size() FDAPDE_COMMA n_rows_));
+              fdapde_assert(
+                std::cmp_equal(ts.size() FDAPDE_COMMA n_rows_), std::invalid_argument,
+                "data row count must match the geometry row count");
               data_.append_vec(colnames[Ns_], ts);
           },
           data...);
@@ -509,7 +522,9 @@ struct GeoLayer {
     }
   
     template <typename T> void load_blk(const std::string& colname, const T& data) {
-        fdapde_assert(std::cmp_equal(data.rows() FDAPDE_COMMA n_rows_));
+        fdapde_assert(
+          std::cmp_equal(data.rows() FDAPDE_COMMA n_rows_), std::invalid_argument,
+          "data row count must match the geometry row count");
         data_.append_blk(colname, data);
         return;
     }
@@ -526,8 +541,8 @@ struct GeoLayer {
         return std::get<N>(geo_data_);
     }
     auto geometry(int i) const {
-        fdapde_assert(i < n_rows_);
-	using internals::apply_index_pack;
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        using internals::apply_index_pack;
         if constexpr (Order == 1) {
             return apply_index_pack<Order>([&]<int... Ns>() { return std::make_tuple(geometry<Ns>()[i]...); });
         } else {
@@ -551,22 +566,22 @@ struct GeoLayer {
 
     // column access
     template <typename T> internals::geo_col_view<T, GeoLayer> col(size_t col) {
-        fdapde_assert(col < cols());
+        fdapde_assert(col < cols(), std::out_of_range, "column index out of range");
         return internals::geo_col_view<T, GeoLayer>(this, data_.header()[col]);
     }
     template <typename T> internals::geo_col_view<T, const GeoLayer> col(size_t col) const {
-        fdapde_assert(col < cols());
+        fdapde_assert(col < cols(), std::out_of_range, "column index out of range");
         return internals::geo_col_view<T, const GeoLayer>(this, data_.header()[col]);
     }
     template <typename T> internals::geo_col_view<T, GeoLayer> col(const std::string& colname) {
-        fdapde_assert(data_.contains(colname));
-	int i = 0;
+        fdapde_assert(data_.contains(colname), std::out_of_range, "column name not found");
+        int i = 0;
         for (; i < cols() && data_.header()[i].colname() != colname; ++i);
         return col<T>(i);
     }
     template <typename T> internals::geo_col_view<T, const GeoLayer> col(const std::string& colname) const {
-        fdapde_assert(data_.contains(colname));
-	int i = 0;
+        fdapde_assert(data_.contains(colname), std::out_of_range, "column name not found");
+        int i = 0;
         for (; i < cols() && data_.header()[i].colname() != colname; ++i);
         return col<T>(i);
     }
@@ -732,16 +747,18 @@ struct GeoLayer {
     // internal reading utility
     template <typename T, typename ParsedFile>
     void load_table_(const std::vector<std::string>& colnames, const ParsedFile& parsed_file) {
-        fdapde_assert(colnames.size() == parsed_file.cols());
-	int i = 0, n_col = parsed_file.cols();
+        fdapde_assert(
+          colnames.size() == parsed_file.cols(), std::invalid_argument, "column name count must match the input table");
+        int i = 0, n_col = parsed_file.cols();
         std::vector<std::vector<T>> data(parsed_file.cols());
         for (const T& s : parsed_file.data()) {
             data[i].push_back(s);
             i = (i + 1) % n_col;
         }
         for (int i = 0; i < n_col; ++i) { data_.append_vec(colnames[i], data[i]); }
-	fdapde_assert(n_rows_ == data_.rows());
-	return;
+        fdapde_assert(
+          n_rows_ == data_.rows(), std::invalid_argument, "data row count must match the geometry row count");
+        return;
     }
     template <typename Scalar>
     Eigen::Matrix<Scalar, Dynamic, Dynamic>
@@ -764,7 +781,12 @@ struct GeoLayer {
         fdapde_static_assert(
           Order == 1 || is_full_geo_point, THIS_METHOD_IS_FOR_ORDER_ONE_OR_FULL_POINT_GEOFRAMES_ONLY);
         constexpr int full_embed_dim = std::accumulate(embed_dim.begin(), embed_dim.end(), 0);
-        fdapde_assert((n_rows_ == 0 || n_rows_ == coords.rows()) && coords.cols() == full_embed_dim);
+        fdapde_assert(
+          n_rows_ == 0 || n_rows_ == coords.rows(), std::invalid_argument,
+          "coordinate row count must match existing geometry");
+        fdapde_assert(
+          coords.cols() == full_embed_dim, std::invalid_argument,
+          "coordinate column count must match the full embedding dimension");
         int offset = 0;
         internals::for_each_index_in_pack<Order>([&]<int Ns_>() {
             Eigen::Matrix<double, Dynamic, Dynamic> coords_ = coords.middleCols(offset, embed_dim[Ns_]);
@@ -800,7 +822,9 @@ struct GeoLayer {
     }
     // single geometric indexes reading utilities
     template <int N> void load_geometry_index_(const Eigen::Matrix<double, Dynamic, Dynamic>& coords) {
-        fdapde_assert(coords.cols() == embed_dim[N]);
+        fdapde_assert(
+          coords.cols() == embed_dim[N], std::invalid_argument,
+          "coordinate column count must match the embedding dimension");
         std::get<N>(geo_data_) = std::tuple_element_t<N, geo_storage_t>(std::get<N>(triangulation_), coords);
         if (n_rows_ == 0) { n_rows_ = coords.rows(); }
         return;
@@ -809,7 +833,7 @@ struct GeoLayer {
         fdapde_static_assert(
           std::is_same_v<POINT FDAPDE_COMMA std::tuple_element_t<N FDAPDE_COMMA GeoInfo>>,
           THIS_METHOD_IS_FOR_POINT_INDEXES_ONLY);
-        fdapde_assert(flag == MESH_NODES);
+        fdapde_assert(flag == MESH_NODES, std::invalid_argument, "point geometry flag must be MESH_NODES");
         std::get<N>(geo_data_) = std::tuple_element_t<N, geo_storage_t>(std::get<N>(triangulation_));
         if (n_rows_ == 0) { n_rows_ = std::get<N>(triangulation_)->nodes().rows(); }
         return;

--- a/fdaPDE/src/geoframe/geoframe.h
+++ b/fdaPDE/src/geoframe/geoframe.h
@@ -123,7 +123,8 @@ template <typename... Triangulation_> struct GeoFrame {
            ...))
     auto& insert_scalar_layer_(const std::string& name, Args&&... args) {
         fdapde_static_assert(sizeof...(GeoInfo) == Order, BAD_LAYER_CONSTRUCTION__NO_MATCHING_ORDER);
-	fdapde_assert(!name.empty() && !has_layer(name));
+        fdapde_assert(!name.empty(), std::invalid_argument, "layer name must not be empty");
+        fdapde_assert(!has_layer(name), std::invalid_argument, "layer name already exists");
         using geo_layer_t = GeoLayer<Triangulation, std::tuple<GeoInfo...>>;
         layers_.emplace_back(
           name,                                                                // layer name
@@ -153,7 +154,8 @@ template <typename... Triangulation_> struct GeoFrame {
         return insert_scalar_layer_<GeoInfo...>(name, row_filter);
     }
     auto& load_shp(const std::string& name, const std::string& filename) {
-        fdapde_assert(!name.empty() && !has_layer(name));
+        fdapde_assert(!name.empty(), std::invalid_argument, "layer name must not be empty");
+        fdapde_assert(!has_layer(name), std::invalid_argument, "layer name already exists");
         auto& l = insert_scalar_layer_<POLYGON>(name, triangulation_);
         l.load_shp(filename);
         return geo_cast<POLYGON>(operator[](name));

--- a/fdaPDE/src/geoframe/point_layer.h
+++ b/fdaPDE/src/geoframe/point_layer.h
@@ -32,7 +32,7 @@ template <typename Triangulation_> struct point_layer {
     point_layer() : triangulation_(nullptr), coords_(), points_at_dofs_(false) { }
     template <typename GeoDescriptor>
         requires(is_eigen_dense_xpr_v<GeoDescriptor> || is_vector_like_v<GeoDescriptor>)
-    point_layer(Triangulation_* triangulation, const GeoDescriptor& coords) noexcept :
+    point_layer(Triangulation_* triangulation, const GeoDescriptor& coords) :
         triangulation_(triangulation), points_at_dofs_(false) {
         if constexpr (is_eigen_dense_xpr_v<GeoDescriptor>) {
             coords_.reserve(coords.size());
@@ -41,7 +41,9 @@ template <typename Triangulation_> struct point_layer {
             }
             n_rows_ = coords.rows();
         } else {
-            fdapde_assert(coords.size() % embed_dim == 0);
+            fdapde_assert(
+              coords.size() % embed_dim == 0, std::invalid_argument,
+              "coordinate count must be divisible by the embedding dimension");
             coords_.reserve(coords.size());
             for (int i = 0, n = coords.size(); i < n; ++i) { coords_.push_back(coords[i]); }
             n_rows_ = coords.size() / embed_dim;
@@ -79,9 +81,11 @@ template <typename Triangulation_> struct point_layer {
             }
             n_rows_ += coords.rows();
         } else {
-            fdapde_assert(coords.size() % embed_dim == 0);
-	    coords_.insert(coords_.end(), coords.begin(), coords.end());
-	    n_rows_ += coords.size() / embed_dim;
+            fdapde_assert(
+              coords.size() % embed_dim == 0, std::invalid_argument,
+              "coordinate count must be divisible by the embedding dimension");
+            coords_.insert(coords_.end(), coords.begin(), coords.end());
+            n_rows_ += coords.size() / embed_dim;
         }
 	return;
     }

--- a/fdaPDE/src/geometry/dcel.h
+++ b/fdaPDE/src/geometry/dcel.h
@@ -46,7 +46,11 @@ template <int LocalDim, int EmbedDim> class DCEL {
         node_t(int id, halfedge_t* halfedge, bool boundary, const CoordsType& coords) :
             id_(id), halfedge_(halfedge), boundary_(boundary), coords_() {
             fdapde_assert(
-              (coords.rows() == 1 && coords.cols() == embed_dim) || (coords.rows() == embed_dim && coords.cols() == 1));
+              coords.rows() == 1 || coords.cols() == 1, std::invalid_argument,
+              "node coordinates must form a row or column vector");
+            fdapde_assert(
+              coords.size() == embed_dim, std::invalid_argument,
+              "node coordinate count must match the embedding dimension");
             if (coords.rows() == 1) {
                 coords_ = coords.transpose();
             } else {
@@ -159,7 +163,9 @@ template <int LocalDim, int EmbedDim> class DCEL {
     DCEL() : nodes_(), halfedges_(), n_nodes_(0), n_halfedges_(0), n_cells_(0) { }
     // constructs a closed loop structure linking nodes one after the other
     static DCEL<local_dim, embed_dim> make_polygon(const Eigen::Matrix<double, Dynamic, Dynamic>& nodes) {
-        fdapde_assert(nodes.cols() == embed_dim);
+        fdapde_assert(
+          nodes.cols() == embed_dim, std::invalid_argument,
+          "node coordinate dimension must match the embedding dimension");
         int n_nodes = nodes.rows();
         DCEL<local_dim, embed_dim> dcel;
         // create polygon cell

--- a/fdaPDE/src/geometry/interval.h
+++ b/fdaPDE/src/geometry/interval.h
@@ -34,8 +34,9 @@ template <> class Triangulation<1, 1> : public TriangulationBase<1, 1, Triangula
 
     Triangulation() = default;
     Triangulation(const Eigen::Matrix<double, Dynamic, 1>& nodes, int flags = 0) : Base() {
-        fdapde_assert(nodes.rows() > 1 && nodes.cols() == 1);
-	Base::flags_ = flags;
+        fdapde_assert(nodes.rows() > 1, std::invalid_argument, "interval requires at least two nodes");
+        fdapde_assert(nodes.cols() == 1, std::invalid_argument, "interval nodes must form a column vector");
+        Base::flags_ = flags;
         nodes_ = nodes;
         // store number of nodes and elements
         n_nodes_ = nodes_.rows();
@@ -105,7 +106,8 @@ template <> class Triangulation<1, 1> : public TriangulationBase<1, 1, Triangula
         if constexpr (Cols == 1) {
             return locate_(p[0]);
         } else {
-            fdapde_assert(p.rows() > 0 && p.cols() == 1);
+            fdapde_assert(p.rows() > 0, std::invalid_argument, "query points must not be empty");
+            fdapde_assert(p.cols() == 1, std::invalid_argument, "interval query points must form a column vector");
             Eigen::Matrix<int, Dynamic, 1> result;
             result.resize(p.rows());
             // start search

--- a/fdaPDE/src/geometry/kd_tree.h
+++ b/fdaPDE/src/geometry/kd_tree.h
@@ -35,7 +35,7 @@ template <int K> class KDTree {
     // computes the kd-tree structure for a set of points
     KDTree() = default;
     template <typename DataType_> explicit KDTree(DataType_&& data) : data_(std::forward<DataType_>(data)) {
-        fdapde_assert(data_.cols() == K);
+        fdapde_assert(data_.cols() == K, std::invalid_argument, "data dimension must match the kd-tree dimension");
         std::vector<int> ids(data_.rows());   // vector of points ids (filled from 0 up to n-1 by std::iota)
         std::iota(ids.begin(), ids.end(), 0);
         int split_dim = 0;   // current hyperplane splitting direction
@@ -74,7 +74,7 @@ template <int K> class KDTree {
 
     // returns an iterator to the nearest neighbor of p. Average O(log(n)) complexity (worst case is O(n))
     iterator nn_search(const Eigen::Matrix<double, Dynamic, 1>& p) const {
-        fdapde_assert(p.size() == K);
+        fdapde_assert(p.size() == K, std::invalid_argument, "query point dimension must match the kd-tree dimension");
         if (kdtree_.empty()) return kdtree_.cend();   // nothing to search
         const data_type& data = data_;
         std::stack<iterator> stack;

--- a/fdaPDE/src/geometry/linear_network.h
+++ b/fdaPDE/src/geometry/linear_network.h
@@ -122,14 +122,15 @@ template <> class Triangulation<1, 2> : public TriangulationBase<1, 2, Triangula
         requires(requires(Lambda lambda, typename Base::NodeType e) {
             { lambda(e) } -> std::same_as<bool>;
         }) {
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         nodes_markers_.resize(n_nodes_);
         for (boundary_node_iterator it = boundary_nodes_begin(); it != boundary_nodes_end(); ++it) {
             nodes_markers_[it->id()] = lambda(*it) ? marker : Unmarked;
         }
     }
     template <int Rows, typename XprType> void mark_boundary(const BinMtxBase<Rows, 1, XprType>& mask) {
-        fdapde_assert(mask.rows() == n_nodes_);
+        fdapde_assert(
+          mask.rows() == n_nodes_, std::invalid_argument, "boundary mask size must match the number of nodes");
         nodes_markers_.resize(n_nodes_);
         for (boundary_node_iterator it = boundary_nodes_begin(); it != boundary_nodes_end(); ++it) {
             nodes_markers_[it->id()] = mask[it->id()] ? 1 : 0;
@@ -140,13 +141,15 @@ template <> class Triangulation<1, 2> : public TriangulationBase<1, 2, Triangula
           std::is_convertible_v<typename Iterator::value_type FDAPDE_COMMA int>, INVALID_ITERATOR_RANGE);
         int n_markers = std::distance(first, last);
 	bool all_markers_positive = std::all_of(first, last, [](auto marker) { return marker >= 0; });
-        fdapde_assert(n_markers == n_nodes() && all_markers_positive);
-        nodes_markers_.resize(n_nodes_, Unmarked);
-        for (int i = 0; i < n_nodes_; ++i) { nodes_markers_[i] = *(first + i); }
+    fdapde_assert(
+      n_markers == n_nodes(), std::invalid_argument, "boundary marker count must match the number of nodes");
+    fdapde_assert(all_markers_positive, std::invalid_argument, "boundary markers must be nonnegative");
+    nodes_markers_.resize(n_nodes_, Unmarked);
+    for (int i = 0; i < n_nodes_; ++i) { nodes_markers_[i] = *(first + i); }
     }
     // marks all boundary edges
     void mark_boundary(int marker) {
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         nodes_markers_.resize(n_nodes_, Unmarked);
         std::for_each(nodes_markers_.begin(), nodes_markers_.end(), [marker](int& marker_) { marker_ = marker; });
     }

--- a/fdaPDE/src/geometry/polygon.h
+++ b/fdaPDE/src/geometry/polygon.h
@@ -29,8 +29,11 @@ template <int LocalDim, int EmbedDim> class Polygon {
 
     // constructors
     Polygon() noexcept = default;
-    Polygon(const Eigen::Matrix<double, Dynamic, Dynamic>& nodes) noexcept : triangulation_() {
-        fdapde_assert(nodes.rows() > 0 && nodes.cols() == embed_dim);
+    Polygon(const Eigen::Matrix<double, Dynamic, Dynamic>& nodes) : triangulation_() {
+        fdapde_assert(nodes.rows() > 0, std::invalid_argument, "polygon nodes must not be empty");
+        fdapde_assert(
+          nodes.cols() == embed_dim, std::invalid_argument,
+          "polygon coordinate dimension must match the embedding dimension");
         if (internals::are_2d_counterclockwise_sorted(nodes)) {
             triangulate_(nodes);
         } else {   // nodes are in clocwise order, reverse node ordering
@@ -40,7 +43,7 @@ template <int LocalDim, int EmbedDim> class Polygon {
             triangulate_(reversed_nodes);
         }
     }
-  
+
     Polygon(const Polygon&) noexcept = default;
     Polygon(Polygon&&) noexcept = default;  
     // observers

--- a/fdaPDE/src/geometry/primitives.h
+++ b/fdaPDE/src/geometry/primitives.h
@@ -53,7 +53,8 @@ template <typename PointList>
 constexpr double signed_measure_2d_polygon(const PointList& points) {
     double area = 0;
     if constexpr (internals::is_eigen_dense_xpr_v<PointList>) {
-        fdapde_assert(points.rows() > 0 && points.cols() == 2);
+        fdapde_assert(points.rows() > 0, std::invalid_argument, "polygon points must not be empty");
+        fdapde_assert(points.cols() == 2, std::invalid_argument, "polygon points must have two coordinates");
         int n_points = points.rows();
         for (int i = 0; i < n_points - 1; ++i) {
             area += (points(i, 0) + points(i + 1, 0)) * (points(i + 1, 1) - points(i, 1));
@@ -61,7 +62,8 @@ constexpr double signed_measure_2d_polygon(const PointList& points) {
         area += (points(n_points - 1, 0) + points(0, 0)) * (points(0, 1) - points(n_points - 1, 1));
     } else if (internals::is_subscriptable<PointList, int>) {
         // assume points to be a RowMajor expansion of the polygon nodes' coordinates
-        fdapde_assert(points.size() % 2 == 0);
+        fdapde_assert(
+          points.size() % 2 == 0, std::invalid_argument, "polygon coordinate count must be divisible by two");
         int n_points = points.size() / 2;
         for (int i = 0; i < n_points - 1; ++i) {
             area += (points[i] + points[i + 2]) * (points[i + 3] - points[i + 1]);

--- a/fdaPDE/src/geometry/tree_search.h
+++ b/fdaPDE/src/geometry/tree_search.h
@@ -78,7 +78,8 @@ template <typename MeshType> class TreeSearch {
     template <typename CoordsMatrix>
         requires(internals::is_eigen_dense_xpr_v<CoordsMatrix>)
     Eigen::Matrix<int, Dynamic, 1> locate(const CoordsMatrix& locs) const {
-        fdapde_assert(locs.cols() == embed_dim);
+        fdapde_assert(
+          locs.cols() == embed_dim, std::invalid_argument, "query point dimension must match the embedding dimension");
         Eigen::Matrix<int, Dynamic, 1> ids(locs.rows());
         for (int i = 0; i < locs.rows(); ++i) { ids[i] = locate(Eigen::Matrix<double, embed_dim, 1>(locs.row(i))); }
         return ids;

--- a/fdaPDE/src/geometry/triangle.h
+++ b/fdaPDE/src/geometry/triangle.h
@@ -67,7 +67,7 @@ template <typename Triangulation> class Triangle : public Simplex<Triangulation:
     bool on_boundary() const { return boundary_; }
     operator bool() const { return mesh_ != nullptr; }
     EdgeType edge(int n) const {
-        fdapde_assert(n < this->n_edges);
+        fdapde_assert(n < this->n_edges, std::out_of_range, "edge index out of range");
         return EdgeType(mesh_->cell_to_edges()(id_, n), mesh_);
     }
     // cell marker

--- a/fdaPDE/src/geometry/triangulation.h
+++ b/fdaPDE/src/geometry/triangulation.h
@@ -59,12 +59,22 @@ template <int LocalDim, int EmbedDim, typename Derived> class TriangulationBase 
 
     TriangulationBase() = default;
     TriangulationBase(const dbl_matrix_t& nodes, const int_matrix_t& cells, const int_matrix_t& boundary, int flags) :
-        nodes_(nodes), cells_(cells), boundary_markers_(boundary), flags_(flags) {
+        nodes_(nodes), cells_(cells), boundary_markers_(), flags_(flags) {
+        fdapde_assert(nodes.rows() > 0, std::invalid_argument, "triangulation nodes must not be empty");
         fdapde_assert(
-          nodes.rows() > 0 && nodes.cols() == embed_dim && cells.rows() > 0 && cells.cols() == n_nodes_per_cell &&
-          boundary.rows() == nodes.rows() && boundary.cols() == 1);
-        fdapde_assert(cells.minCoeff() >= 0);
-	int min = cells.minCoeff();
+          nodes.cols() == embed_dim, std::invalid_argument,
+          "node coordinate dimension must match the embedding dimension");
+        fdapde_assert(cells.rows() > 0, std::invalid_argument, "triangulation cells must not be empty");
+        fdapde_assert(
+          cells.cols() == n_nodes_per_cell, std::invalid_argument,
+          "cell width must match the number of nodes per cell");
+        fdapde_assert(
+          boundary.rows() == nodes.rows(), std::invalid_argument,
+          "boundary marker count must match the number of nodes");
+        fdapde_assert(boundary.cols() == 1, std::invalid_argument, "boundary markers must form a column vector");
+        fdapde_assert(cells.minCoeff() >= 0, std::invalid_argument, "cell node identifiers must be nonnegative");
+        boundary_markers_ = boundary;
+        int min = cells.minCoeff();
         if (min != 0) { cells_ = cells_.array() - min; }   // scale cell numbering to start from zero
         // store number of nodes and number of cells
         n_nodes_ = nodes_.rows();
@@ -131,11 +141,21 @@ template <int LocalDim, int EmbedDim, typename Derived> class TriangulationBase 
         int marker() const { return marker_; }
     };
     CellIterator<Derived> cells_begin(int marker = TriangulationAll) const {
-        fdapde_assert(marker == TriangulationAll || (marker >= 0 && cells_markers_.size() != 0));
+        fdapde_assert(
+          marker == TriangulationAll || marker >= 0, std::invalid_argument,
+          "cell marker must be nonnegative or TriangulationAll");
+        fdapde_assert(
+          marker == TriangulationAll || cells_markers_.size() != 0, std::logic_error,
+          "cell markers must be initialized before filtering");
         return CellIterator<Derived>(0, static_cast<const Derived*>(this), marker);
     }
     CellIterator<Derived> cells_end(int marker = TriangulationAll) const {
-        fdapde_assert(marker == TriangulationAll || (marker >= 0 && cells_markers_.size() != 0));
+        fdapde_assert(
+          marker == TriangulationAll || marker >= 0, std::invalid_argument,
+          "cell marker must be nonnegative or TriangulationAll");
+        fdapde_assert(
+          marker == TriangulationAll || cells_markers_.size() != 0, std::logic_error,
+          "cell markers must be initialized before filtering");
         return CellIterator<Derived>(n_cells_, static_cast<const Derived*>(this), marker);
     }
     // set cells markers
@@ -144,14 +164,14 @@ template <int LocalDim, int EmbedDim, typename Derived> class TriangulationBase 
         requires(requires(Lambda lambda, CellType c) {
             { lambda(c) } -> std::same_as<bool>;
         }) {
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         cells_markers_.resize(n_cells_, Unmarked);
         for (cell_iterator it = cells_begin(); it != cells_end(); ++it) {
             cells_markers_[it->id()] = lambda(*it) ? marker : Unmarked;
         }
     }
     template <int Rows, typename XprType> void mark_cells(const BinMtxBase<Rows, 1, XprType>& mask) {
-        fdapde_assert(mask.rows() == n_cells_);
+        fdapde_assert(mask.rows() == n_cells_, std::invalid_argument, "cell mask size must match the number of cells");
         cells_markers_.resize(n_cells_, Unmarked);
         for (cell_iterator it = cells_begin(); it != cells_end(); ++it) {
             cells_markers_[it->id()] = mask[it->id()] ? 1 : 0;
@@ -162,12 +182,13 @@ template <int LocalDim, int EmbedDim, typename Derived> class TriangulationBase 
           std::is_convertible_v<typename Iterator::value_type FDAPDE_COMMA int>, INVALID_ITERATOR_RANGE);
         int n_markers = std::distance(first, last);
         bool all_markers_positive = std::all_of(first, last, [](auto marker) { return marker >= 0; });
-        fdapde_assert(n_markers == n_cells_ && all_markers_positive);
+        fdapde_assert(n_markers == n_cells_, std::invalid_argument, "cell marker count must match the number of cells");
+        fdapde_assert(all_markers_positive, std::invalid_argument, "cell markers must be nonnegative");
         cells_markers_.resize(n_cells_, Unmarked);
         for (int i = 0; i < n_cells_; ++i) { cells_markers_[i] = *(first + i); }
     }
     void mark_cells(int marker) {   // marks all cells with m
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         cells_markers_.resize(n_cells_);
 	std::for_each(cells_markers_.begin(), cells_markers_.end(), [marker](int& marker_) { marker_ = marker; });
     }
@@ -382,7 +403,8 @@ template <int N> class Triangulation<2, N> : public TriangulationBase<2, N, Tria
     // icoshpere surface generation
     static Triangulation<2, N> Sphere(double radius, int n_refinments, int flags = 0) {
         fdapde_static_assert(N == 3, THIS_METHOD_IS_FOR_THREE_DIMENSIONAL_SURFACE_TRIANGULATIONS_ONLY);
-        fdapde_assert(radius > 0 && n_refinments > 0);
+        fdapde_assert(radius > 0, std::invalid_argument, "sphere radius must be positive");
+        fdapde_assert(n_refinments > 0, std::invalid_argument, "sphere refinement count must be positive");
         // unit icosahedron construction
         constexpr double a = 1.0;
         constexpr double b = 1.0 / std::numbers::phi;   // inverse golden ratio
@@ -545,7 +567,7 @@ template <int N> class Triangulation<2, N> : public TriangulationBase<2, N, Tria
         requires(requires(Lambda lambda, EdgeType e) {
             { lambda(e) } -> std::same_as<bool>;
         }) {
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         edges_markers_.resize(n_edges_);
         for (boundary_edge_iterator it = boundary_edges_begin(); it != boundary_edges_end(); ++it) {
             if (lambda(*it)) {
@@ -554,7 +576,8 @@ template <int N> class Triangulation<2, N> : public TriangulationBase<2, N, Tria
         }
     }
     template <int Rows, typename XprType> void mark_boundary(const BinMtxBase<Rows, 1, XprType>& mask) {
-        fdapde_assert(mask.rows() == n_edges_);
+        fdapde_assert(
+          mask.rows() == n_edges_, std::invalid_argument, "boundary mask size must match the number of edges");
         edges_markers_.resize(n_edges_, 0);
         for (boundary_edge_iterator it = boundary_edges_begin(); it != boundary_edges_end(); ++it) {
             if(mask[it->id()]){
@@ -567,14 +590,16 @@ template <int N> class Triangulation<2, N> : public TriangulationBase<2, N, Tria
           std::is_convertible_v<typename Iterator::value_type FDAPDE_COMMA int>, INVALID_ITERATOR_RANGE);
         int n_markers = std::distance(first, last);
 	bool all_markers_positive = std::all_of(first, last, [](auto marker) { return marker >= 0; });
-        fdapde_assert(n_markers == n_edges() && all_markers_positive);
-        edges_markers_.resize(n_edges_, Unmarked);
-        for (int i = 0; i < n_edges_; ++i) { edges_markers_[i] = *(first + i); }
-        return;
+    fdapde_assert(
+      n_markers == n_edges(), std::invalid_argument, "boundary marker count must match the number of edges");
+    fdapde_assert(all_markers_positive, std::invalid_argument, "boundary markers must be nonnegative");
+    edges_markers_.resize(n_edges_, Unmarked);
+    for (int i = 0; i < n_edges_; ++i) { edges_markers_[i] = *(first + i); }
+    return;
     }
     // marks all boundary edges
     void mark_boundary(int marker) {
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         edges_markers_.resize(n_edges_, Unmarked);
         std::for_each(edges_markers_.begin(), edges_markers_.end(), [marker](int& marker_) { marker_ = marker; });
     }
@@ -902,7 +927,7 @@ template <> class Triangulation<3, 3> : public TriangulationBase<3, 3, Triangula
         requires(requires(Lambda lambda, FaceType e) {
             { lambda(e) } -> std::same_as<bool>;
         }) {
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         faces_markers_.resize(n_faces_, Unmarked);
 	edges_markers_.resize(n_edges_, Unmarked);
         for (boundary_face_iterator it = boundary_faces_begin(); it != boundary_faces_end(); ++it) {
@@ -914,7 +939,8 @@ template <> class Triangulation<3, 3> : public TriangulationBase<3, 3, Triangula
         return;
     }
     template <int Rows, typename XprType> void mark_boundary(const BinMtxBase<Rows, 1, XprType>& mask) {
-        fdapde_assert(mask.rows() == n_edges_);
+        fdapde_assert(
+          mask.rows() == n_edges_, std::invalid_argument, "boundary mask size must match the number of edges");
         faces_markers_.resize(n_faces_, 0);
 	edges_markers_.resize(n_edges_, 0);
         for (boundary_face_iterator it = boundary_faces_begin(); it != boundary_faces_end(); ++it) {
@@ -929,19 +955,21 @@ template <> class Triangulation<3, 3> : public TriangulationBase<3, 3, Triangula
           std::is_convertible_v<typename Iterator::value_type FDAPDE_COMMA int>, INVALID_ITERATOR_RANGE);
         int n_markers = std::distance(first, last);
 	bool all_markers_positive = std::all_of(first, last, [](auto marker) { return marker >= 0; });
-        fdapde_assert(n_markers == n_faces() && all_markers_positive);
-        faces_markers_.resize(n_faces_, Unmarked);
-        edges_markers_.resize(n_edges_, Unmarked);
-        for (int i = 0; i < n_faces_; ++i) {
-            int marker = *(first + i);
-            faces_markers_[i] = marker;
-            for (int edge_id : face_to_edges().row(i)) { edges_markers_[edge_id] = marker; }
-        }
+    fdapde_assert(
+      n_markers == n_faces(), std::invalid_argument, "boundary marker count must match the number of faces");
+    fdapde_assert(all_markers_positive, std::invalid_argument, "boundary markers must be nonnegative");
+    faces_markers_.resize(n_faces_, Unmarked);
+    edges_markers_.resize(n_edges_, Unmarked);
+    for (int i = 0; i < n_faces_; ++i) {
+        int marker = *(first + i);
+        faces_markers_[i] = marker;
+        for (int edge_id : face_to_edges().row(i)) { edges_markers_[edge_id] = marker; }
+    }
         return;
     }
     // marks all boundary faces
     void mark_boundary(int marker) {
-        fdapde_assert(marker >= 0);
+        fdapde_assert(marker >= 0, std::invalid_argument, "marker must be nonnegative");
         faces_markers_.resize(n_faces_, Unmarked);
         edges_markers_.resize(n_edges_, Unmarked);
         for (auto it = boundary_begin(); it != boundary_end(); ++it) {

--- a/fdaPDE/src/geometry/walk_search.h
+++ b/fdaPDE/src/geometry/walk_search.h
@@ -55,7 +55,8 @@ template <typename MeshType> class WalkSearch {
     template <typename CoordsMatrix>
         requires(internals::is_eigen_dense_xpr_v<CoordsMatrix>)
     Eigen::Matrix<int, Dynamic, 1> locate(const CoordsMatrix& locs) const {
-        fdapde_assert(locs.cols() == embed_dim);
+        fdapde_assert(
+          locs.cols() == embed_dim, std::invalid_argument, "query point dimension must match the embedding dimension");
         Eigen::Matrix<int, Dynamic, 1> ids(locs.rows());
         for (int i = 0; i < locs.rows(); ++i) { ids[i] = locate(Eigen::Matrix<double, embed_dim, 1>(locs.row(i))); }
         return ids;

--- a/fdaPDE/src/io/batched_istream.h
+++ b/fdaPDE/src/io/batched_istream.h
@@ -59,7 +59,7 @@ struct batched_istream_impl {
     const char* data() const { return buff_; }
     size_t tellg() const { return pos_; }
     batched_istream_impl& seekg(size_t pos) {
-        fdapde_assert(pos < n_blk_);
+        fdapde_assert(pos < n_blk_, std::out_of_range, "stream position exceeds the buffered block");
         pos_ = pos;
         return *this;
     }

--- a/fdaPDE/src/io/csv.h
+++ b/fdaPDE/src/io/csv.h
@@ -34,7 +34,10 @@ internals::table_reader<T> read_csv(const std::string& filename, bool header = t
 template <typename DataT>
     requires(internals::is_eigen_dense_xpr_v<DataT>)
 void write_csv(const std::string& filename, const DataT& data, const std::vector<std::string>& colnames) {
-    fdapde_assert(data.cols() > 0 && std::cmp_equal(data.cols() FDAPDE_COMMA colnames.size()));
+    fdapde_assert(data.cols() > 0, std::invalid_argument, "CSV data must contain columns");
+    fdapde_assert(
+      std::cmp_equal(data.cols() FDAPDE_COMMA colnames.size()), std::invalid_argument,
+      "column name count must match the CSV column count");
     const static Eigen::IOFormat CSVFormat(Eigen::FullPrecision, Eigen::DontAlignCols, ", ", "\n");
     std::ofstream file(filename);
     for (std::size_t i = 0; i < colnames.size() - 1; ++i) { file << colnames[i] << ", "; }
@@ -59,7 +62,12 @@ template <typename DataT>
 void write_csv(
   const std::string& filename, const DataT& data, int rows, int cols, const std::vector<std::string>& colnames,
   bool by_rows = true) {
-    fdapde_assert(data.size() % (rows * cols) == 0 && std::cmp_equal(cols FDAPDE_COMMA colnames.size()));
+    fdapde_assert(
+      data.size() % (rows * cols) == 0, std::invalid_argument,
+      "CSV data size must be divisible by the requested matrix size");
+    fdapde_assert(
+      std::cmp_equal(cols FDAPDE_COMMA colnames.size()), std::invalid_argument,
+      "column name count must match the CSV column count");
     std::ofstream file(filename);
     for (std::size_t i = 0; i < colnames.size() - 1; ++i) { file << colnames[i] << ", "; }
     file << colnames.back() << "\n";

--- a/fdaPDE/src/io/parsing.h
+++ b/fdaPDE/src/io/parsing.h
@@ -265,7 +265,8 @@ template <typename T> class table_reader {
         {
             std::string cmp = "";
             for (; i < n_cols_ && cmp != colname; ++i) { cmp = colnames_[i]; }
-	    fdapde_assert(i < n_cols_ && cmp == colname);
+            fdapde_assert(i < n_cols_, std::out_of_range, "column index out of range");
+            fdapde_assert(cmp == colname, std::out_of_range, "column name not found");
         }
         for (int j = 0; j < n_rows_; ++j) { col_[i] = data_[i + j * n_cols_]; }
 	return col_;

--- a/fdaPDE/src/io/shp.h
+++ b/fdaPDE/src/io/shp.h
@@ -305,24 +305,27 @@ class shp_reader {
     int n_points() const { return points_.size(); }
     const sf_point_t& point(int index) const {
         fdapde_assert(
-          shape_type() == shape_t::Point || shape_type() == shape_t::PointZ || shape_type() == shape_t::PointM);
+          shape_type() == shape_t::Point || shape_type() == shape_t::PointZ || shape_type() == shape_t::PointM,
+          std::logic_error, "shapefile does not contain point records");
         return points_[index];
     }
     const sf_polyline_t& polyline(int index) const {
         fdapde_assert(
-          shape_type() == shape_t::PolyLine || shape_type() == shape_t::PolyLineZ ||
-          shape_type() == shape_t::PolyLineM);
+          shape_type() == shape_t::PolyLine || shape_type() == shape_t::PolyLineZ || shape_type() == shape_t::PolyLineM,
+          std::logic_error, "shapefile does not contain polyline records");
         return polylines_[index];
     }
     const sf_polygon_t& polygon(int index) const {
         fdapde_assert(
-          shape_type() == shape_t::Polygon || shape_type() == shape_t::PolygonZ || shape_type() == shape_t::PolygonM);
+          shape_type() == shape_t::Polygon || shape_type() == shape_t::PolygonZ || shape_type() == shape_t::PolygonM,
+          std::logic_error, "shapefile does not contain polygon records");
         return polygons_[index];
     }
     const sf_multipoint_t& multipoint(int index) const {
         fdapde_assert(
           shape_type() == shape_t::MultiPoint || shape_type() == shape_t::MultiPointZ ||
-          shape_type() == shape_t::MultiPointM);
+            shape_type() == shape_t::MultiPointM,
+          std::logic_error, "shapefile does not contain multipoint records");
         return multipoints_[index];
     }
 };
@@ -401,7 +404,7 @@ class dbf_reader {
         }
     }
     template <typename T> std::vector<T> get_as(std::string colname) const {
-        fdapde_assert(data_.count(colname) == 1);
+        fdapde_assert(data_.count(colname) == 1, std::out_of_range, "column name not found");
         if constexpr (std::is_same_v<T, std::string>) {
             std::vector<std::string> values;
             values.reserve(data_.at(colname).size());

--- a/fdaPDE/src/linear_algebra/eigen_helper.h
+++ b/fdaPDE/src/linear_algebra/eigen_helper.h
@@ -63,12 +63,12 @@ template <typename SolverType_> class eigen_sparse_solver_movable_wrap {
     void factorize(const MatrixType& matrix) { solver_->factorize(matrix); }
     template <typename XprType>   // solve method, dense  rhs operand
     const Eigen::Solve<SolverType, XprType> solve(const Eigen::MatrixBase<XprType>& b) const {
-        fdapde_assert(bool(solver_) == true);
+        fdapde_assert(bool(solver_) == true, std::logic_error, "solver is not initialized");
         return solver_->solve(b);
     }
     template <typename XprType>   // solve method, sparse rhs operand
     const Eigen::Solve<SolverType, XprType> solve(const Eigen::SparseMatrixBase<XprType>& b) const {
-        fdapde_assert(bool(solver_) == true);
+        fdapde_assert(bool(solver_) == true, std::logic_error, "solver is not initialized");
         return solver_->solve(b);
     }
     // observers

--- a/fdaPDE/src/linear_algebra/fspai.h
+++ b/fdaPDE/src/linear_algebra/fspai.h
@@ -50,24 +50,25 @@ template <typename Index_, int Options_> struct sparsity_pattern {
         typename std::vector<Index>::const_iterator begin() const { return nnzeros_.begin(); }
         typename std::vector<Index>::const_iterator end() const { return nnzeros_.end(); }
         Index operator[](Index i) const {   // access the i-th nonzero of the line
-            fdapde_assert(static_cast<std::size_t>(i) < nnzeros_.size());
+            fdapde_assert(
+              static_cast<std::size_t>(i) < nnzeros_.size(), std::out_of_range, "nonzero index out of range");
             return nnzeros_[i];
         }
         Index size() const { return size_; }
         bool has_nnzero_at(Index pos) const { return std::find(nnzeros_.begin(), nnzeros_.end(), pos); }
         bool empty() const { return nnzeros_.size() == 0; }
         typename std::vector<Index>::const_iterator find(Index pos) const {
-            fdapde_assert(pos < size_);
+            fdapde_assert(pos < size_, std::out_of_range, "sparsity position out of range");
             return std::find(nnzeros_.begin(), nnzeros_.end(), pos);
         }
         // modifiers
         void nnzero_insert_unique(Index pos) {   // ammortized O(log(n)) insertion with uniqueness guarantees
-            fdapde_assert(pos < size_);
+            fdapde_assert(pos < size_, std::out_of_range, "sparsity position out of range");
             if (std::upper_bound(nnzeros_.begin(), nnzeros_.end(), pos) == nnzeros_.end()) { nnzeros_.push_back(pos); }
             return;
         }
         void nnzero_insert(Index pos) {
-            fdapde_assert(pos < size_);
+            fdapde_assert(pos < size_, std::out_of_range, "sparsity position out of range");
             nnzeros_.push_back(pos);
         }
         void resize(Index size) { size_ = size; }
@@ -104,11 +105,11 @@ template <typename Index_, int Options_> struct sparsity_pattern {
     }
     // accessors
     const value_type& operator[](Index i) const {
-        fdapde_assert(i < outer_size_);
+        fdapde_assert(i < outer_size_, std::out_of_range, "sparsity line index out of range");
         return sparsity_[i];
     }
     value_type& operator[](Index i) {
-        fdapde_assert(i < outer_size_);
+        fdapde_assert(i < outer_size_, std::out_of_range, "sparsity line index out of range");
         return sparsity_[i];
     }
     const value_type& operator()(Index i, Index j) const { return sparsity_[i][j]; }
@@ -262,19 +263,21 @@ struct FSPAI {
     FSPAI(const FSPAI&) noexcept = default;
     FSPAI(FSPAI&&) noexcept = default;
 
-    FSPAI(const MatrixType& matrix) noexcept : L_() { compute(matrix); }
-    FSPAI(const MatrixType& matrix, int alpha, int beta, double epsilon) noexcept :
+    FSPAI(const MatrixType& matrix) : L_() { compute(matrix); }
+    FSPAI(const MatrixType& matrix, int alpha, int beta, double epsilon) :
         L_(), alpha_(alpha), beta_(beta), epsilon_(epsilon) {
         compute(matrix, alpha_, beta_, epsilon_);
     }
 
     // computes an approximation of the Cholesky factor of matrix
     void compute(const MatrixType& matrix) {
-        fdapde_assert(matrix.rows() == matrix.cols() && matrix.rows() > 0 && matrix.cols() > 0);
+        fdapde_assert(matrix.rows() == matrix.cols(), std::invalid_argument, "FSPAI requires a square matrix");
+        fdapde_assert(matrix.rows() > 0, std::invalid_argument, "FSPAI requires a nonempty matrix");
         compute_impl_(matrix, alpha_, beta_, epsilon_);   // use defaults      
     }
     void compute(const MatrixType& matrix, int alpha, int beta, double epsilon) {
-        fdapde_assert(matrix.rows() == matrix.cols() && matrix.rows() > 0 && matrix.cols() > 0);
+        fdapde_assert(matrix.rows() == matrix.cols(), std::invalid_argument, "FSPAI requires a square matrix");
+        fdapde_assert(matrix.rows() > 0, std::invalid_argument, "FSPAI requires a nonempty matrix");
         compute_impl_(matrix, alpha, beta, epsilon);
     }
     // accessors
@@ -286,21 +289,25 @@ struct FSPAI {
 
     // linear system solve
     template <typename Other> void solveInPlace(Eigen::MatrixBase<Other>& other) const {
-        fdapde_assert(L_.rows() == other.rows());
-	other = inverse() * other;
+        fdapde_assert(
+          L_.rows() == other.rows(), std::invalid_argument, "right-hand side row count must match the factorization");
+        other = inverse() * other;
     }
     template <typename Other> void solveInPlace(Eigen::SparseMatrixBase<Other>& other) const {
-        fdapde_assert(L_.rows() == other.rows());
-	other = inverse() * other;
+        fdapde_assert(
+          L_.rows() == other.rows(), std::invalid_argument, "right-hand side row count must match the factorization");
+        other = inverse() * other;
     }  
     template <typename Other>
     Eigen::Matrix<double, Dynamic, Dynamic> solve(const Eigen::MatrixBase<Other>& other) const {
-        fdapde_assert(L_.rows() == other.rows());
+        fdapde_assert(
+          L_.rows() == other.rows(), std::invalid_argument, "right-hand side row count must match the factorization");
         return inverse() * other;
     }
     template <typename Other>
     Eigen::SparseMatrix<double> solve(const Eigen::SparseMatrixBase<Other>& other) const {
-        fdapde_assert(L_.rows() == other.rows());
+        fdapde_assert(
+          L_.rows() == other.rows(), std::invalid_argument, "right-hand side row count must match the factorization");
         return inverse() * other;
     }  
 };

--- a/fdaPDE/src/linear_algebra/lumping.h
+++ b/fdaPDE/src/linear_algebra/lumping.h
@@ -24,7 +24,9 @@ namespace fdapde {
 // returns the lumped matrix of a sparse expression. row-sum lumping operator
 template <typename ExprType>
 Eigen::SparseMatrix<typename ExprType::Scalar> lump(const Eigen::SparseMatrixBase<ExprType>& expr) {
-    fdapde_assert(expr.rows() == expr.cols());   // stop if not square
+    fdapde_assert(
+      expr.rows() == expr.cols(), std::invalid_argument,
+      "matrix lumping requires a square matrix");   // stop if not square
     using Scalar_ = typename ExprType::Scalar;
     // reserve space for triplets
     std::vector<Triplet<Scalar_>> triplet_list;
@@ -40,7 +42,9 @@ Eigen::SparseMatrix<typename ExprType::Scalar> lump(const Eigen::SparseMatrixBas
 // returns the lumped matrix of a dense expression. row-sum lumping operator
 template <typename ExprType>
 Eigen::DiagonalMatrix<typename ExprType::Scalar, Dynamic, Dynamic> lump(const Eigen::MatrixBase<ExprType>& expr) {
-    fdapde_assert(expr.rows() == expr.cols());   // stop if not square
+    fdapde_assert(
+      expr.rows() == expr.cols(), std::invalid_argument,
+      "matrix lumping requires a square matrix");   // stop if not square
     using Scalar_ = typename ExprType::Scalar;
     // matrix lumping
     Eigen::Matrix<Scalar_, Dynamic, 1> lumped_matrix = expr.array().rowwise().sum();

--- a/fdaPDE/src/linear_algebra/rp_chol.h
+++ b/fdaPDE/src/linear_algebra/rp_chol.h
@@ -31,17 +31,15 @@ class RpChol {
    public:
   
     RpChol() noexcept = default;
-    RpChol(const MatrixType& A, double tol, int block_sz, int max_iter, int seed = random_seed) noexcept :
-        block_sz_(block_sz),
-        max_iter_(max_iter),
-        seed_(seed == random_seed ? std::random_device()() : seed) {
+    RpChol(const MatrixType& A, double tol, int block_sz, int max_iter, int seed = random_seed) :
+        block_sz_(block_sz), max_iter_(max_iter), seed_(seed == random_seed ? std::random_device()() : seed) {
         compute(A, tol);
     }
     RpChol(int block_sz, int max_iter, int seed = random_seed) noexcept :
         block_sz_(block_sz), max_iter_(max_iter), seed_(seed == random_seed ? std::random_device()() : seed) { }
   
     void compute(const MatrixType& A, double tol) {
-        fdapde_assert(tol < 1);
+        fdapde_assert(tol < 1, std::invalid_argument, "Cholesky tolerance must be less than one");
         int rows = A.rows();
         int cols = A.cols();
 

--- a/fdaPDE/src/linear_algebra/sparse_block_matrix.h
+++ b/fdaPDE/src/linear_algebra/sparse_block_matrix.h
@@ -52,7 +52,7 @@ struct SparseBlockMatrix :
     SparseBlockMatrix() noexcept = default;
     // initialize from list of matrices
     template <typename... Block>
-    SparseBlockMatrix(Block&&... m) noexcept
+    SparseBlockMatrix(Block&&... m)
         requires(sizeof...(Block) > 1 && sizeof...(Block) == Rows_ * Cols_)
     {
         fdapde_static_assert(
@@ -64,7 +64,9 @@ struct SparseBlockMatrix :
                 row_dims[Ns_] = arg.rows();
                 col_dims[Ns_] = arg.cols();
             } else {
-                fdapde_assert(arg == 0);   // allows only 0 placeholder
+                fdapde_assert(
+                  arg == 0, std::invalid_argument,
+                  "scalar block placeholders must be zero");   // allows only 0 placeholder
                 row_dims[Ns_] = -1;
                 col_dims[Ns_] = -1;
             }
@@ -76,8 +78,10 @@ struct SparseBlockMatrix :
             while (k < Cols_ && row_dims[i * Cols_ + k] == -1) { k++; }
             int row = (k == Cols_) ? 1 : row_dims[i * Cols_ + k];
             for (int j = 0; j < Cols_; ++j) {
-                fdapde_assert(row_dims[i * Cols_ + j] == row || row_dims[i * Cols_ + j] == -1);
-		// normalize row dimensions, if still considered dynamic
+                fdapde_assert(
+                  row_dims[i * Cols_ + j] == row || row_dims[i * Cols_ + j] == -1, std::invalid_argument,
+                  "block row dimensions must match");
+                // normalize row dimensions, if still considered dynamic
                 if (row_dims[i * Cols_ + j] == -1) { row_dims[i * Cols_ + j] = row; }
             }
         }
@@ -88,7 +92,9 @@ struct SparseBlockMatrix :
             while (k < Rows_ && col_dims[i + k * Cols_] == -1) { k++; }
             int col = (k == Rows_) ? 1 : col_dims[i + k * Cols_];
             for (int j = 0; j < Rows_; ++j) {
-                fdapde_assert(col_dims[i + k * Cols_] == col || col_dims[i + k * Cols_] == -1);
+                fdapde_assert(
+                  col_dims[i + k * Cols_] == col || col_dims[i + k * Cols_] == -1, std::invalid_argument,
+                  "block column dimensions must match");
                 // normalize col dimensions, if still considered dynamic
                 if (col_dims[i + k * Cols_] == -1) { col_dims[i + k * Cols_] = col; }
             }
@@ -138,7 +144,10 @@ struct SparseBlockMatrix :
                      { e.size() } -> std::convertible_to<std::size_t>;
                  })
     SparseBlockMatrix(const Extents& blk_rows, const Extents& blk_cols) : inner_size_(blk_rows), outer_size_(blk_cols) {
-        fdapde_assert(blk_rows.size() == Rows_ && blk_cols.size() == Cols_);
+        fdapde_assert(
+          blk_rows.size() == Rows_, std::invalid_argument, "block row extent count must match the block layout");
+        fdapde_assert(
+          blk_cols.size() == Cols_, std::invalid_argument, "block column extent count must match the block layout");
         outer_offset_[0] = 0;
         inner_offset_[0] = 0;
         for (Eigen::Index i = 0; i < Rows_; ++i) {
@@ -167,11 +176,17 @@ struct SparseBlockMatrix :
     }
     // read/write access to individual blocks
     const Eigen::SparseMatrix<double>& block(Eigen::Index row, Eigen::Index col) const {
-        fdapde_assert(row >= 0 && row < Rows_ && col >= 0 && col < Cols_);
+        fdapde_assert(row >= 0, std::out_of_range, "row index must be nonnegative");
+        fdapde_assert(row < Rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(col >= 0, std::out_of_range, "column index must be nonnegative");
+        fdapde_assert(col < Cols_, std::out_of_range, "column index out of range");
         return blocks_[row * Cols_ + col];
     }
     Eigen::SparseMatrix<double>& block(Eigen::Index row, Eigen::Index col) {
-        fdapde_assert(row >= 0 && row < Rows_ && col >= 0 && col < Cols_);
+        fdapde_assert(row >= 0, std::out_of_range, "row index must be nonnegative");
+        fdapde_assert(row < Rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(col >= 0, std::out_of_range, "column index must be nonnegative");
+        fdapde_assert(col < Cols_, std::out_of_range, "column index out of range");
         return blocks_[row * Cols_ + col];
     }
     // provides an estimate of the nonzero elements of the matrix
@@ -214,12 +229,18 @@ struct SparseBlockMatrix :
     }
     // accessors
     Scalar& coeffRef(Eigen::Index row, Eigen::Index col) {
-        fdapde_assert(row >= 0 && row < rows_ && col >= 0 && col < cols_);
+        fdapde_assert(row >= 0, std::out_of_range, "row index must be nonnegative");
+        fdapde_assert(row < rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(col >= 0, std::out_of_range, "column index must be nonnegative");
+        fdapde_assert(col < cols_, std::out_of_range, "column index out of range");
         return blocks_[innerBlockIndex(row) * Cols_ + outerBlockIndex(col)].coeffRef(
           indexToBlockInner(row), indexToBlockOuter(col));
     }
     Scalar coeff(Eigen::Index row, Eigen::Index col) const {
-        fdapde_assert(row >= 0 && row < rows_ && col >= 0 && col < cols_);
+        fdapde_assert(row >= 0, std::out_of_range, "row index must be nonnegative");
+        fdapde_assert(row < rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(col >= 0, std::out_of_range, "column index must be nonnegative");
+        fdapde_assert(col < cols_, std::out_of_range, "column index out of range");
         return blocks_[innerBlockIndex(row) * Cols_ + outerBlockIndex(col)].coeffRef(
           indexToBlockInner(row), indexToBlockOuter(col));
     }
@@ -250,7 +271,8 @@ struct SparseBlockMatrix :
     }
     template <typename TripletList>
     inline void setBlockFromTriplets(Eigen::Index row, Eigen::Index col, const TripletList& triplet_list) {
-        fdapde_assert(row < Rows_ && col < Cols_);
+        fdapde_assert(row < Rows_, std::out_of_range, "block row index out of range");
+        fdapde_assert(col < Cols_, std::out_of_range, "block column index out of range");
         block(row, col).setFromTriplets(triplet_list.begin(), triplet_list.end());
     }
    protected:

--- a/fdaPDE/src/optimization/grid_search.h
+++ b/fdaPDE/src/optimization/grid_search.h
@@ -36,7 +36,10 @@ template <int N> class GridSearch {
     double obj_curr;
     // constructor
     GridSearch() : size_(N) { fdapde_static_assert(N != Dynamic, THIS_METHOD_IS_FOR_STATIC_SIZED_GRID_SEARCH_ONLY); }
-    GridSearch(int size) : size_(N == Dynamic ? size : N) { fdapde_assert(N == Dynamic || size == N); }
+    GridSearch(int size) : size_(N == Dynamic ? size : N) {
+        fdapde_assert(
+          N == Dynamic || size == N, std::invalid_argument, "grid search dimension must match the static dimension");
+    }
     GridSearch(const GridSearch& other) : size_(other.size_) { }
     GridSearch& operator=(const GridSearch& other) {
         size_ = other.size_;
@@ -56,16 +59,18 @@ template <int N> class GridSearch {
             }
         }());
         using grid_t = MdMap<const double, MdExtents<Dynamic, Dynamic>, layout_policy>;
-        constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 	
         std::tuple<Callbacks...> callbacks_ {callbacks...};
         grid_t grid_;
         value_ = std::numeric_limits<double>::max();
         if constexpr (internals::is_vector_like_v<GridT>) {
-            fdapde_assert(grid.size() % size_ == 0);
+            fdapde_assert(
+              grid.size() % size_ == 0, std::invalid_argument,
+              "grid coordinate count must be divisible by the search dimension");
             grid_ = grid_t(grid.data(), grid.size() / size_, size_);
         } else {
-            fdapde_assert(grid.cols() == size_);
+            fdapde_assert(
+              grid.cols() == size_, std::invalid_argument, "grid column count must match the search dimension");
             grid_ = grid_t(grid.data(), grid.rows(), size_);
         }
         bool stop = false;   // asserted true in case of forced stop

--- a/fdaPDE/src/optimization/lbfgs.h
+++ b/fdaPDE/src/optimization/lbfgs.h
@@ -46,7 +46,7 @@ template <int N> class LBFGS {
     LBFGS() : max_iter_(500), tol_(1e-5), step_(1e-2) { }
     LBFGS(int max_iter, double tol, double step, int mem_size) :
         max_iter_(max_iter), tol_(tol), step_(step), mem_size_(mem_size) {
-        fdapde_assert(mem_size_ >= 0);
+        fdapde_assert(mem_size_ >= 0, std::invalid_argument, "LBFGS history size must be nonnegative");
     }
     LBFGS(const LBFGS& other) :
         max_iter_(other.max_iter_), tol_(other.tol_), step_(other.step_), mem_size_(other.mem_size_) { }

--- a/fdaPDE/src/optimization/nelder_mead.h
+++ b/fdaPDE/src/optimization/nelder_mead.h
@@ -56,7 +56,7 @@ template <int N> class NelderMead {
         fdapde_static_assert(
           std::is_same<decltype(std::declval<ObjectiveT>().operator()(vector_t())) FDAPDE_COMMA double>::value,
           INVALID_CALL_TO_OPTIMIZE__OBJECTIVE_FUNCTOR_NOT_ACCEPTING_VECTORTYPE);
-        fdapde_assert(x0.rows() > 0);
+        fdapde_assert(x0.rows() > 0, std::invalid_argument, "initial optimization point must not be empty");
         std::tuple<Callbacks...> callbacks_ {callbacks...};
         double dims = x0.rows();
         bool stop = false;

--- a/fdaPDE/src/splines/bs_space.h
+++ b/fdaPDE/src/splines/bs_space.h
@@ -126,9 +126,9 @@ template <typename Triangulation_> class BsSpace {
     }
     // return i-th basis function on physical domain
     SpFunction<BsSpace<Triangulation_>> operator[](int i) {
-        fdapde_assert(i < dof_handler_.n_dofs());
-	Eigen::Matrix<double, Dynamic, 1> coeff = Eigen::Matrix<double, Dynamic, 1>::Zero(dof_handler_.n_dofs());
-	coeff[i] = 1;
+        fdapde_assert(i < dof_handler_.n_dofs(), std::out_of_range, "basis function index out of range");
+        Eigen::Matrix<double, Dynamic, 1> coeff = Eigen::Matrix<double, Dynamic, 1>::Zero(dof_handler_.n_dofs());
+        coeff[i] = 1;
         return BsFunction<BsSpace<Triangulation_>>(*this, coeff);
     }
    private:

--- a/fdaPDE/src/splines/bspline_basis.h
+++ b/fdaPDE/src/splines/bspline_basis.h
@@ -40,7 +40,9 @@ class BSplineBasis {
                     { knots.size() } -> std::convertible_to<std::size_t>;
                 })
     BSplineBasis(KnotsVectorType&& knots, int order) : order_(order) {
-        fdapde_assert(std::is_sorted(knots.begin() FDAPDE_COMMA knots.end(), std::less_equal<double>()));
+        fdapde_assert(
+          std::is_sorted(knots.begin() FDAPDE_COMMA knots.end(), std::less_equal<double>()), std::invalid_argument,
+          "spline knots must be strictly increasing");
         int n = knots.size();
         knots_.resize(n);
         for (int i = 0; i < n; ++i) { knots_[i] = knots[i]; }
@@ -52,7 +54,9 @@ class BSplineBasis {
     BSplineBasis(const Triangulation<1, 1>& interval, int order) : order_(order) {
         // construct knots vector
         Eigen::Matrix<double, Dynamic, 1> knots = interval.nodes();
-        fdapde_assert(std::is_sorted(knots.begin() FDAPDE_COMMA knots.end() FDAPDE_COMMA std::less_equal<double>()));
+        fdapde_assert(
+          std::is_sorted(knots.begin() FDAPDE_COMMA knots.end() FDAPDE_COMMA std::less_equal<double>()),
+          std::invalid_argument, "spline knots must be strictly increasing");
         int n = knots.size();
         knots_.resize(n + 2 * order_);
         // pad the knot vector to obtain a full basis for the whole knot span [knots[0], knots[n-1]]

--- a/fdaPDE/src/splines/dof_handler.h
+++ b/fdaPDE/src/splines/dof_handler.h
@@ -130,11 +130,21 @@ template <> class DofHandler<1, 1, spline_tag> {
     };  
     cell_iterator cells_begin(int marker = TriangulationAll) const {
         const std::vector<int>& cells_markers = triangulation_->cells_markers();
-        fdapde_assert(marker == TriangulationAll || (marker >= 0 && cells_markers.size() != 0));
+        fdapde_assert(
+          marker == TriangulationAll || marker >= 0, std::invalid_argument,
+          "cell marker must be nonnegative or TriangulationAll");
+        fdapde_assert(
+          marker == TriangulationAll || cells_markers.size() != 0, std::logic_error,
+          "cell markers must be initialized before filtering");
         return cell_iterator(0, this, marker);
     }
     cell_iterator cells_end(int marker = TriangulationAll) const {
-        fdapde_assert(marker == TriangulationAll || (marker >= 0 && triangulation_->cells_markers().size() != 0));
+        fdapde_assert(
+          marker == TriangulationAll || marker >= 0, std::invalid_argument,
+          "cell marker must be nonnegative or TriangulationAll");
+        fdapde_assert(
+          marker == TriangulationAll || triangulation_->cells_markers().size() != 0, std::logic_error,
+          "cell markers must be initialized before filtering");
         return cell_iterator(triangulation_->n_cells(), this, marker);
     }
 

--- a/fdaPDE/src/splines/sp_assembler_base.h
+++ b/fdaPDE/src/splines/sp_assembler_base.h
@@ -91,12 +91,15 @@ struct sp_assembler_base {
         test_space_(std::addressof(internals::test_space(form_))),
         begin_(begin),
         end_(end) {
-        fdapde_assert(dof_handler_->n_dofs() > 0);
+        fdapde_assert(
+          dof_handler_->n_dofs() > 0, std::logic_error, "degrees of freedom must be initialized before assembly");
         // copy quadrature rule
 	Eigen::Matrix<double, Dynamic, Dynamic> quad_nodes__;
         if constexpr (sizeof...(quadrature) == 1) {
             auto quad_rule = std::get<0>(std::make_tuple(quadrature...));
-            fdapde_assert(local_dim == quad_rule.local_dim);
+            fdapde_assert(
+              local_dim == quad_rule.local_dim, std::invalid_argument,
+              "quadrature dimension must match the spline dimension");
             quad_nodes__ .resize(quad_rule.order, quad_rule.local_dim);
             quad_weights_.resize(quad_rule.order, 1);
             for (int i = 0; i < quad_rule.order; ++i) {

--- a/fdaPDE/src/splines/sp_bilinear_form_assembler.h
+++ b/fdaPDE/src/splines/sp_bilinear_form_assembler.h
@@ -63,7 +63,12 @@ class sp_bilinear_form_assembly_loop :
         if constexpr (is_petrov_galerkin) {
             trial_dof_handler_ = std::addressof(internals::trial_space(form_).dof_handler());
         }
-        fdapde_assert(test_dof_handler()->n_dofs() != 0 && trial_dof_handler()->n_dofs() != 0);
+        fdapde_assert(
+          test_dof_handler()->n_dofs() != 0, std::logic_error,
+          "test degrees of freedom must be initialized before assembly");
+        fdapde_assert(
+          trial_dof_handler()->n_dofs() != 0, std::logic_error,
+          "trial degrees of freedom must be initialized before assembly");
         if constexpr (sizeof...(Quadrature_) == 0) {
             // default to higher-order quadrature
             if (test_space_->order() != trial_space_->order()) {

--- a/fdaPDE/src/splines/sp_integration.h
+++ b/fdaPDE/src/splines/sp_integration.h
@@ -130,7 +130,8 @@ template <typename T>
         { t.resize(i, j) } -> std::same_as<void>;
     })
 void get_sp_quadrature(int order, T& quad_nodes, T& quad_weights) {
-    fdapde_assert(order >= 0 && order <= 7);
+    fdapde_assert(order >= 0, std::invalid_argument, "spline quadrature order must be nonnegative");
+    fdapde_assert(order <= 7, std::invalid_argument, "spline quadrature order must not exceed seven");
     auto copy_ = []<typename QuadRule>(QuadRule q, T& quad_nodes_, T& quad_weights_) {
         quad_nodes_  .resize(q.order, q.local_dim);
         quad_weights_.resize(q.order, q.local_dim);

--- a/fdaPDE/src/splines/sp_objects.h
+++ b/fdaPDE/src/splines/sp_objects.h
@@ -263,7 +263,10 @@ template <typename SpSpace_> class BsFunction : public ScalarFieldBase<SpSpace_:
     }
     BsFunction(SpSpace_& sp_space, const Eigen::Matrix<double, Dynamic, 1>& coeff) :
         sp_space_(std::addressof(sp_space)), coeff_(coeff) {
-        fdapde_assert(coeff.size() > 0 && coeff.size() == sp_space_->n_dofs());
+        fdapde_assert(coeff.size() > 0, std::invalid_argument, "coefficient vector must not be empty");
+        fdapde_assert(
+          coeff.size() == sp_space_->n_dofs(), std::invalid_argument,
+          "coefficient count must match the number of degrees of freedom");
     }
     Scalar operator()(const InputType& p) const { 
         int e_id = sp_space_->triangulation().locate(p);
@@ -312,7 +315,10 @@ template <typename SpSpace_> class BsFunction : public ScalarFieldBase<SpSpace_:
     }
     // assignment from expansion coefficient vector
     BsFunction& operator=(const Eigen::Matrix<double, Dynamic, 1>& coeff) {
-        fdapde_assert(coeff.size() > 0 && coeff.size() == sp_space_->n_dofs());
+        fdapde_assert(coeff.size() > 0, std::invalid_argument, "coefficient vector must not be empty");
+        fdapde_assert(
+          coeff.size() == sp_space_->n_dofs(), std::invalid_argument,
+          "coefficient count must match the number of degrees of freedom");
         coeff_ = coeff;
         return *this;
     }

--- a/fdaPDE/src/tp_space.h
+++ b/fdaPDE/src/tp_space.h
@@ -319,7 +319,10 @@ class TpFunction :
     }
     TpFunction(TpSpace_& tp_space, const Eigen::Matrix<double, Dynamic, 1>& coeff) :
         tp_space_(&tp_space), coeff_(coeff) {
-        fdapde_assert(coeff.size() > 0 && coeff.size() == tp_space_->n_dofs());
+        fdapde_assert(coeff.size() > 0, std::invalid_argument, "coefficient vector must not be empty");
+        fdapde_assert(
+          coeff.size() == tp_space_->n_dofs(), std::invalid_argument,
+          "coefficient count must match the number of degrees of freedom");
     }
     template <typename... InputType_>
         requires(sizeof...(InputType_) == tp_order)
@@ -355,7 +358,10 @@ class TpFunction :
         internals::for_each_index_and_args<tp_order>(
           [&]<int Ns_, typename InputType__>(const InputType__& grid) {
               using function_space_t = std::tuple_element_t<Ns_, FunctionSpaces>;
-              fdapde_assert(grid.rows() > 0 && grid.cols() == function_space_t::embed_dim);
+              fdapde_assert(grid.rows() > 0, std::invalid_argument, "evaluation grid must not be empty");
+              fdapde_assert(
+                grid.cols() == function_space_t::embed_dim, std::invalid_argument,
+                "evaluation grid dimension must match the function space");
               const auto& function_space = std::get<Ns_>(tp_space_->function_spaces());
               index_t n_shape_functions = function_space.n_shape_functions();
               index_t n_points = grid.rows();
@@ -422,7 +428,10 @@ class TpFunction :
     }
     // assignment from expansion coeff vector
     TpFunction& operator=(const Eigen::Matrix<double, Dynamic, 1>& coeff) {
-        fdapde_assert(coeff.size() > 0 && coeff.size() == tp_space_->n_dofs());
+        fdapde_assert(coeff.size() > 0, std::invalid_argument, "coefficient vector must not be empty");
+        fdapde_assert(
+          coeff.size() == tp_space_->n_dofs(), std::invalid_argument,
+          "coefficient count must match the number of degrees of freedom");
         coeff_ = coeff;
         return *this;
     }

--- a/fdaPDE/src/utility/assert.h
+++ b/fdaPDE/src/utility/assert.h
@@ -17,43 +17,27 @@
 #ifndef __FDAPDE_ASSERT_H__
 #define __FDAPDE_ASSERT_H__
 
-#include "header_check.h"
-
-namespace fdapde {
+#include <stdexcept>
 
 #define FDAPDE_COMMA ,
-  
-namespace internals {
-  
-inline void fdapde_assert_failed_(const char* str, const char* file, int line) {
-    std::cerr << file << ":" << line << ". Assertion: '" << str << "' failed." << std::endl;
-    abort();
-}
 
-}   // namespace internals
+/// @brief throws the requested exception on failure, including when debug checks are disabled
+#define fdapde_strong_assert(condition, exception_type, message)                                                       \
+    do {                                                                                                               \
+        if (!(condition)) { throw exception_type(message); }                                                           \
+    } while (false)
 
+/// @brief checks a precondition in debug mode without evaluating disabled arguments
 #ifdef FDAPDE_NO_DEBUG
-#    define fdapde_assert(condition) (void)0
+#    define fdapde_assert(condition, exception_type, message) ((void)0)
 #else
-#    define fdapde_assert(condition)                                                                                   \
-        if (!(condition)) { internals::fdapde_assert_failed_(#condition, __FILE__, __LINE__); }
-  
-#endif   // NDEBUG
+#    define fdapde_assert(condition, exception_type, message)                                                          \
+        fdapde_strong_assert((condition), exception_type, (message))
+#endif
 
 #define fdapde_static_assert(condition, message) static_assert(condition, #message)
 
-#ifdef FDAPDE_NO_DEBUG
-#    define fdapde_constexpr_assert(condition) (void)0
-#else
-#    define fdapde_constexpr_assert(condition)                                                                         \
-        if (std::is_constant_evaluated()) {                                                                            \
-            if (!(condition)) { throw std::logic_error(#condition); }                                                  \
-        } else {                                                                                                       \
-            fdapde_assert(condition);                                                                                  \
-        }
-
-#endif   // NDEBUG
-
-}   // namespace fdapde
+/// @brief preserves the legacy constexpr check with the same debug-only runtime behavior
+#define fdapde_constexpr_assert(condition)       fdapde_assert((condition), std::logic_error, #condition)
 
 #endif   // __FDAPDE_ASSERT_H__

--- a/fdaPDE/src/utility/binary.h
+++ b/fdaPDE/src/utility/binary.h
@@ -145,7 +145,11 @@ template <int Rows, int Cols = Rows> class BinaryMatrix : public BinMtxBase<Rows
     typename std::enable_if<Rows_ == Dynamic || Cols_ == Dynamic, void>::type
     resize(int rows, int cols) {
         fdapde_assert(
-          (Rows_ == Dynamic || (Rows_ == 1 && rows == 1)) && (Cols_ == Dynamic || (Cols_ == 1 && cols == 1)));
+          Rows_ == Dynamic || (Rows_ == 1 && rows == 1), std::invalid_argument,
+          "row count must match the static vector extent");
+        fdapde_assert(
+          Cols_ == Dynamic || (Cols_ == 1 && cols == 1), std::invalid_argument,
+          "column count must match the static vector extent");
         n_rows_ = rows;
         n_cols_ = cols;
         Base::n_bitpacks_ = 1 + std::ceil((n_rows_ * n_cols_) / PackSize);
@@ -171,7 +175,8 @@ template <int Rows, int Cols = Rows> class BinaryMatrix : public BinMtxBase<Rows
     BitPackType& bitpack(int i) { return data_[i]; }   // non-const access to i-th bitpack
     // setters
     void set(int i, int j) {   // set (i,j)-th bit
-        fdapde_assert(i < n_rows_ && j < n_cols_);
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(j < n_cols_, std::out_of_range, "column index out of range");
         data_[pack_of(i, j)] |= (BitPackType(1) << ((i * Base::n_cols_ + j) % PackSize));
     }
     void set(int i) {
@@ -186,7 +191,8 @@ template <int Rows, int Cols = Rows> class BinaryMatrix : public BinMtxBase<Rows
         }
     }  
     void clear(int i, int j) {   // clear (i,j)-th bit (sets to 0)
-        fdapde_assert(i < n_rows_ && j < n_cols_);
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(j < n_cols_, std::out_of_range, "column index out of range");
         data_[pack_of(i, j)] &= ~(BitPackType(1) << ((i * Base::n_cols_ + j) % PackSize));
     }
     void clear(int i) {
@@ -274,7 +280,8 @@ struct BinMtxBinaryOp : public BinMtxBase<Rows, Cols, BinMtxBinaryOp<Rows, Cols,
 
     BinMtxBinaryOp(const Lhs& op1, const Rhs& op2, BinaryOperation f) :
         Base(op1.rows(), op1.cols()), op1_(op1), op2_(op2), f_(f) {
-        fdapde_assert(op1_.rows() == op2_.rows() && op1_.cols() == op2_.cols());
+        fdapde_assert(op1_.rows() == op2_.rows(), std::invalid_argument, "operand row counts must match");
+        fdapde_assert(op1_.cols() == op2_.cols(), std::invalid_argument, "operand column counts must match");
     }
     bool operator()(int i, int j) const { return f_(op1_(i, j), op2_(i, j)); }
     BitPackType bitpack(int i) const { return f_(op1_.bitpack(i), op2_.bitpack(i)); }
@@ -309,28 +316,38 @@ class BinMtxBlock : public BinMtxBase<BlockRows, BlockCols, BinMtxBlock<BlockRow
         start_row_(BlockRows == 1 ? i : 0),
         start_col_(BlockCols == 1 ? i : 0) {
         fdapde_static_assert(BlockRows == 1 || BlockCols == 1, THIS_METHOD_IS_ONLY_FOR_ROW_AND_COLUMN_BLOCKS);
-        fdapde_assert(i >= 0 && ((BlockRows == 1 && i < xpr_.rows()) || (BlockCols == 1 && i < xpr_.cols())));
+        fdapde_assert(i >= 0, std::out_of_range, "block index must be nonnegative");
+        fdapde_assert(
+          (BlockRows == 1 && i < xpr_.rows()) || (BlockCols == 1 && i < xpr_.cols()), std::out_of_range,
+          "block index out of range");
     }
     // fixed-sized constructor
     BinMtxBlock(XprTypeNested& xpr, int start_row, int start_col) :
         Base(BlockRows, BlockCols), xpr_(xpr), start_row_(start_row), start_col_(start_col) {
         fdapde_static_assert(
           BlockRows != Dynamic && BlockCols != Dynamic, THIS_METHOD_IS_ONLY_FOR_STATIC_SIZED_MATRIX_BLOCKS);
-        fdapde_assert(
-          start_row_ >= 0 && BlockRows >= 0 && start_row_ + BlockRows <= xpr_.rows() && start_col_ >= 0 &&
-          BlockCols >= 0 && start_col_ + BlockCols <= xpr_.cols());
+        fdapde_assert(start_row_ >= 0, std::out_of_range, "block starting row must be nonnegative");
+        fdapde_assert(BlockRows >= 0, std::invalid_argument, "block row count must be nonnegative");
+        fdapde_assert(start_row_ + BlockRows <= xpr_.rows(), std::out_of_range, "block exceeds the available rows");
+        fdapde_assert(start_col_ >= 0, std::out_of_range, "block starting column must be nonnegative");
+        fdapde_assert(BlockCols >= 0, std::invalid_argument, "block column count must be nonnegative");
+        fdapde_assert(start_col_ + BlockCols <= xpr_.cols(), std::out_of_range, "block exceeds the available columns");
     }
     // dynamic-sized constructor
     BinMtxBlock(XprTypeNested& xpr, int start_row, int start_col, int block_rows, int block_cols) :
         Base(block_rows, block_cols), xpr_(xpr), start_row_(start_row), start_col_(start_col) {
-        fdapde_assert(BlockRows == Dynamic || BlockCols == Dynamic);
         fdapde_assert(
-          start_row_ >= 0 && start_row_ + block_rows <= xpr_.rows() && start_col_ >= 0 &&
-          start_col_ + block_cols <= xpr_.cols());
+          BlockRows == Dynamic || BlockCols == Dynamic, std::logic_error,
+          "runtime block sizes require a dynamic block extent");
+        fdapde_assert(start_row_ >= 0, std::out_of_range, "block starting row must be nonnegative");
+        fdapde_assert(start_row_ + block_rows <= xpr_.rows(), std::out_of_range, "block exceeds the available rows");
+        fdapde_assert(start_col_ >= 0, std::out_of_range, "block starting column must be nonnegative");
+        fdapde_assert(start_col_ + block_cols <= xpr_.cols(), std::out_of_range, "block exceeds the available columns");
     }
 
     bool operator()(int i, int j) const {
-        fdapde_assert(i < n_rows_ && j < n_cols_);
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(j < n_cols_, std::out_of_range, "column index out of range");
         return xpr_(i + start_row_, j + start_col_);
     }
     void set(int i, int j) { xpr_.set(i + start_row_, j + start_col_); }
@@ -364,7 +381,8 @@ class BinMtxBlock : public BinMtxBase<BlockRows, BlockCols, BinMtxBlock<BlockRow
           (BlockRows == Dynamic || BlockCols == Dynamic) || (BlockRows == Rows_ && BlockCols == Cols_) ||
             (BlockCols == 1 && (Rows_ == 1 || Cols_ == 1)),
           INVALID_BLOCK_ASSIGNMENT);
-        fdapde_assert(rhs.rows() == n_rows_ && rhs.cols() == n_cols_);
+        fdapde_assert(rhs.rows() == n_rows_, std::invalid_argument, "operand row counts must match");
+        fdapde_assert(rhs.cols() == n_cols_, std::invalid_argument, "operand column counts must match");
         for (int i = 0; i < rhs.rows(); ++i) {
             for (int j = 0; j < rhs.cols(); ++j) {
                 if (rhs(i, j)) set(i, j);
@@ -481,7 +499,8 @@ class BinMtxRepeatOp : public BinMtxBase<Rows, Cols, BinMtxRepeatOp<Rows, Cols, 
         Base(xpr.rows() * rep_row, xpr.cols() * rep_col), xpr_(xpr), rep_row_(rep_row), rep_col_(rep_col) {
     }
     bool operator()(int i, int j) const {
-        fdapde_assert(i < n_rows_ && j < n_cols_);
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(j < n_cols_, std::out_of_range, "column index out of range");
         return xpr_(i % xpr_.rows(), j % xpr_.cols());
     }
     BitPackType bitpack(int i) const {
@@ -511,10 +530,13 @@ public:
   
     BinMtxReshapeOp(const XprTypeNested& xpr, int reshaped_rows, int reshaped_cols) :
         Base(reshaped_rows, reshaped_cols), xpr_(xpr), reshaped_rows_(reshaped_rows), reshaped_cols_(reshaped_cols) {
-        fdapde_assert(reshaped_rows * reshaped_cols == xpr.rows() * xpr.cols());
+        fdapde_assert(
+          reshaped_rows * reshaped_cols == xpr.rows() * xpr.cols(), std::invalid_argument,
+          "reshaping must preserve the number of coefficients");
     }
     bool operator()(int i, int j) const {
-        fdapde_assert(i < reshaped_rows_ && j < reshaped_cols_);
+        fdapde_assert(i < reshaped_rows_, std::out_of_range, "reshaped row index out of range");
+        fdapde_assert(j < reshaped_cols_, std::out_of_range, "reshaped column index out of range");
         return xpr_((i * reshaped_cols_ + j) / xpr_.cols(), (i * reshaped_cols_ + j) % xpr_.cols());
     }
     BitPackType bitpack(int i) const { return xpr_.bitpack(i); }   // no changes in storage layout
@@ -546,7 +568,8 @@ template <int Rows, int Cols, typename XprType> class BinMtxBase {
     const XprType& get() const { return static_cast<const XprType&>(*this); }
     // access operator on base type E
     bool operator()(int i, int j) const {
-        fdapde_assert(i < n_rows_ && j < n_cols_);
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(j < n_cols_, std::out_of_range, "column index out of range");
         return get().operator()(i, j);
     }
     bool operator[](int i) const {
@@ -619,7 +642,8 @@ template <int Rows, int Cols, typename XprType> class BinMtxBase {
         requires(internals::is_eigen_dense_xpr_v<ExprType> && std::is_convertible_v<Scalar, typename ExprType::Scalar>)
     Eigen::Matrix<typename ExprType::Scalar, Dynamic, Dynamic>
     select(const Eigen::MatrixBase<ExprType>& mtx, Scalar false_val = Scalar(0)) const {
-        fdapde_assert(n_rows_ == mtx.rows() && n_cols_ == mtx.cols());
+        fdapde_assert(n_rows_ == mtx.rows(), std::invalid_argument, "mask and matrix row counts must match");
+        fdapde_assert(n_cols_ == mtx.cols(), std::invalid_argument, "mask and matrix column counts must match");
         using Scalar_ = typename ExprType::Scalar;
         Eigen::Matrix<Scalar_, Dynamic, Dynamic> masked_mtx = mtx;   // assign to dense storage
         for (int i = 0; i < n_rows_; ++i) {
@@ -637,8 +661,15 @@ template <int Rows, int Cols, typename XprType> class BinMtxBase {
     Eigen::Matrix<typename TrueExpr::Scalar, Dynamic, Dynamic>
     select(const Eigen::MatrixBase<TrueExpr>& true_expr, const Eigen::MatrixBase<FalseExpr>& false_expr) {
         fdapde_assert(
-          n_rows_ == true_expr.rows() && n_cols_ == true_expr.cols() && true_expr.rows() == false_expr.rows() &&
-          true_expr.cols() == false_expr.cols());
+          n_rows_ == true_expr.rows(), std::invalid_argument, "mask and true expression row counts must match");
+        fdapde_assert(
+          n_cols_ == true_expr.cols(), std::invalid_argument, "mask and true expression column counts must match");
+        fdapde_assert(
+          true_expr.rows() == false_expr.rows(), std::invalid_argument,
+          "true and false expression row counts must match");
+        fdapde_assert(
+          true_expr.cols() == false_expr.cols(), std::invalid_argument,
+          "true and false expression column counts must match");
         using Scalar_ = typename TrueExpr::Scalar;
         Eigen::Matrix<Scalar_, Dynamic, Dynamic> masked_mtx = true_expr;
         Eigen::Matrix<Scalar_, Dynamic, Dynamic> tmp = false_expr;   // evaluate false_expr in temporary
@@ -654,7 +685,8 @@ template <int Rows, int Cols, typename XprType> class BinMtxBase {
         requires(internals::is_eigen_sparse_xpr_v<ExprType> && std::is_convertible_v<Scalar, typename ExprType::Scalar>)
     Eigen::SparseMatrix<typename ExprType::Scalar>
     select(const Eigen::SparseMatrixBase<ExprType>& mtx, Scalar false_val = Scalar(0)) const {
-        fdapde_assert(n_rows_ == mtx.rows() && n_cols_ == mtx.cols());
+        fdapde_assert(n_rows_ == mtx.rows(), std::invalid_argument, "mask and matrix row counts must match");
+        fdapde_assert(n_cols_ == mtx.cols(), std::invalid_argument, "mask and matrix column counts must match");
         using Scalar_ = typename ExprType::Scalar;
 	Eigen::SparseMatrix<Scalar_> masked_mtx = mtx;   // assign to sparse storage
         for (int k = 0; k < masked_mtx.outerSize(); ++k) {
@@ -671,8 +703,15 @@ template <int Rows, int Cols, typename XprType> class BinMtxBase {
     Eigen::SparseMatrix<typename TrueExpr::Scalar>
     select(const Eigen::SparseMatrixBase<TrueExpr>& true_expr, const Eigen::SparseMatrixBase<FalseExpr>& false_expr) {
         fdapde_assert(
-          n_rows_ == true_expr.rows() && n_cols_ == true_expr.cols() && true_expr.rows() == false_expr.rows() &&
-          true_expr.cols() == false_expr.cols());
+          n_rows_ == true_expr.rows(), std::invalid_argument, "mask and true expression row counts must match");
+        fdapde_assert(
+          n_cols_ == true_expr.cols(), std::invalid_argument, "mask and true expression column counts must match");
+        fdapde_assert(
+          true_expr.rows() == false_expr.rows(), std::invalid_argument,
+          "true and false expression row counts must match");
+        fdapde_assert(
+          true_expr.cols() == false_expr.cols(), std::invalid_argument,
+          "true and false expression column counts must match");
         using Scalar_ = typename TrueExpr::Scalar;
         Eigen::SparseMatrix<Scalar_> masked_mtx = true_expr;
         Eigen::SparseMatrix<Scalar_> tmp = false_expr;   // evaluate false_expr in temporary
@@ -721,7 +760,8 @@ bool operator==(const BinMtxBase<Rows1, Cols1, XprType1>& op1, const BinMtxBase<
       !(Rows1 != Dynamic && Cols1 != Dynamic && Rows2 != Dynamic && Cols2 != Dynamic) ||
         (Rows1 == Cols1 && Rows2 == Cols2),
       YOU_MIXED_MATRICES_OF_DIFFERENT_SIZE);
-    fdapde_assert(op1.rows() == op2.rows() && op1.cols() == op2.cols());
+    fdapde_assert(op1.rows() == op2.rows(), std::invalid_argument, "operand row counts must match");
+    fdapde_assert(op1.cols() == op2.cols(), std::invalid_argument, "operand column counts must match");
     using BitPackType = typename XprType1::BitPackType;
     static constexpr int PackSize = XprType1::PackSize;
     bool result = true;
@@ -738,7 +778,8 @@ bool operator!=(const BinMtxBase<Rows1, Cols1, XprType1>& op1, const BinMtxBase<
       !(Rows1 != Dynamic && Cols1 != Dynamic && Rows2 != Dynamic && Cols2 != Dynamic) ||
         (Rows1 == Cols1 && Rows2 == Cols2),
       YOU_MIXED_MATRICES_OF_DIFFERENT_SIZE);
-    fdapde_assert(op1.rows() == op2.rows() && op1.cols() == op2.cols());
+    fdapde_assert(op1.rows() == op2.rows(), std::invalid_argument, "operand row counts must match");
+    fdapde_assert(op1.cols() == op2.cols(), std::invalid_argument, "operand column counts must match");
     using BitPackType = typename XprType1::BitPackType;
     static constexpr int PackSize = XprType1::PackSize;    
     bool result = false;
@@ -827,7 +868,8 @@ class BinaryMap : public BinMtxBase<Rows, Cols, BinaryMap<Rows, Cols, XprTypeNes
     BitPackType& bitpack(int i) { return data_[i]; }   // non-const access to i-th bitpack
 
     void set(int i, int j) {   // set (i,j)-th bit
-        fdapde_assert(i < n_rows_ && j < n_cols_);
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(j < n_cols_, std::out_of_range, "column index out of range");
         data_[pack_of(i, j)] |= (BitPackType(1) << ((i * n_cols_ + j) % PackSize));
     }
     void set(int i) {
@@ -842,7 +884,8 @@ class BinaryMap : public BinMtxBase<Rows, Cols, BinaryMap<Rows, Cols, XprTypeNes
         }
     }  
     void clear(int i, int j) {   // clear (i,j)-th bit (sets to 0)
-        fdapde_assert(i < n_rows_ && j < n_cols_);
+        fdapde_assert(i < n_rows_, std::out_of_range, "row index out of range");
+        fdapde_assert(j < n_cols_, std::out_of_range, "column index out of range");
         data_[pack_of(i, j)] &= ~(BitPackType(1) << ((i * n_cols_ + j) % PackSize));
     }
     void clear(int i) {

--- a/fdaPDE/src/utility/binary_tree.h
+++ b/fdaPDE/src/utility/binary_tree.h
@@ -257,7 +257,7 @@ template <typename T> class BinaryTree {
     }
     // sets this tree as a deep copy of other
     void clone_(const BinaryTree& other) {
-        fdapde_assert(!other.empty());
+        fdapde_assert(!other.empty(), std::logic_error, "source tree must not be empty when cloning");
         clear();
         // insert new root and clone by bfs visit
         root_ = new node_type(*other.root(), 0);

--- a/fdaPDE/src/utility/matrix.h
+++ b/fdaPDE/src/utility/matrix.h
@@ -380,8 +380,10 @@ class MatrixBlock : public MatrixBase<BlockRows_, BlockCols_, MatrixBlock<BlockR
     constexpr MatrixBlock(Derived& xpr, int i) :
         start_row_(BlockRows_ == 1 ? i : 0), start_col_(BlockCols_ == 1 ? i : 0), xpr_(xpr) {
         fdapde_static_assert(BlockRows_ == 1 || BlockCols_ == 1, THIS_METHOD_IS_ONLY_FOR_ROW_AND_COLUMN_BLOCKS);
-        fdapde_constexpr_assert(
-          i >= 0 && ((BlockRows_ == 1 && i < xpr_.rows()) || (BlockCols_ == 1 && i < xpr_.cols())));
+        fdapde_assert(i >= 0, std::out_of_range, "block index must be nonnegative");
+        fdapde_assert(
+          ((BlockRows_ == 1 && i < xpr_.rows()) || (BlockCols_ == 1 && i < xpr_.cols())), std::out_of_range,
+          "block index out of range");
     }
     constexpr MatrixBlock(Derived& xpr, int start_row, int start_col) :
         start_row_(start_row), start_col_(start_col), xpr_(xpr) { }
@@ -442,7 +444,8 @@ class Matrix : public MatrixBase<Rows_, Cols_, Matrix<Scalar_, Rows_, Cols_, Nes
     constexpr Matrix() : data_() {};
     constexpr explicit Matrix(const std::array<Scalar, Rows * Cols>& data) : data_(data) { }
     constexpr explicit Matrix(const std::vector<Scalar>& data) : data_() {
-        fdapde_constexpr_assert(data.size() == Rows * Cols);
+        fdapde_assert(
+          data.size() == Rows * Cols, std::invalid_argument, "coefficient count must match the matrix size");
         for (int i = 0; i < rows(); ++i) {
             for (int j = 0; j < cols(); ++j) { data_[i * Cols + j] = data[i * Cols + j]; }
         }
@@ -616,7 +619,7 @@ template <typename XprType, typename Functor> struct linear_matrix_redux_op {
     using Scalar = typename XprType::Scalar;
 
     static constexpr Scalar run(const XprType& xpr, Scalar init, Functor f) {
-        fdapde_constexpr_assert(xpr.size() > 0);
+        fdapde_assert(xpr.size() > 0, std::invalid_argument, "matrix reduction requires a nonempty expression");
         Scalar res = init;
         int rows_ = xpr.rows(), cols_ = xpr.cols();
         for (int i = 0; i < rows_; ++i) {
@@ -672,7 +675,8 @@ template <int Rows, int Cols, typename Derived> struct MatrixBase {
     // redux operators
     template <typename Scalar_, typename Functor> constexpr auto redux(Scalar_ init, Functor&& f) const {
         using Scalar = typename Derived::Scalar;
-        fdapde_constexpr_assert(derived().rows() > 0 && derived().cols() > 0);
+        fdapde_assert(derived().rows() > 0, std::invalid_argument, "matrix reduction requires at least one row");
+        fdapde_assert(derived().cols() > 0, std::invalid_argument, "matrix reduction requires at least one column");
         fdapde_static_assert(
           std::is_convertible_v<Scalar_ FDAPDE_COMMA Scalar>, INVALID_SCALAR_INIT_TYPE_IN_REDUX_OPERATION);
         // perform reduction loop
@@ -979,7 +983,8 @@ template <typename MatrixType> class PartialPivLU {
     template <typename RhsType> constexpr Matrix<Scalar, Size, 1> solve(const RhsType& rhs) {
         fdapde_static_assert(
           std::is_same_v<Scalar FDAPDE_COMMA typename RhsType::Scalar>, INVALID_SCALAR_TYPE_FOR_RHS_OPERAND);
-        fdapde_constexpr_assert(rhs.rows() == Size && rhs.cols() == 1);
+        fdapde_assert(rhs.rows() == Size, std::invalid_argument, "right-hand side size must match the factorization");
+        fdapde_assert(rhs.cols() == 1, std::invalid_argument, "right-hand side must be a column vector");
         Matrix<Scalar, Size, 1> x;
         // evaluate U^{-1} * (L^{-1} * (P * rhs))
         x = P_ * rhs;
@@ -1007,7 +1012,8 @@ class Map : public MatrixBase<Rows_, Cols_, Map<Scalar_, Rows_, Cols_, StorageOr
         data_(data), outer_stride_(outer_stride), inner_stride_(inner_stride) { }
     // const access
     constexpr Scalar operator()(int i, int j) const {
-        fdapde_assert(i < Rows && j < Cols);
+        fdapde_assert(i < Rows, std::out_of_range, "row index out of range");
+        fdapde_assert(j < Cols, std::out_of_range, "column index out of range");
         return data_[i * rowStride() + j * colStride()];
     }
     constexpr Scalar operator[](int i) const
@@ -1017,7 +1023,8 @@ class Map : public MatrixBase<Rows_, Cols_, Map<Scalar_, Rows_, Cols_, StorageOr
     }
     // non-const access
     constexpr Scalar& operator()(int i, int j) {
-        fdapde_assert(i < Rows && j < Cols);
+        fdapde_assert(i < Rows, std::out_of_range, "row index out of range");
+        fdapde_assert(j < Cols, std::out_of_range, "column index out of range");
         return data_[i * rowStride() + j * colStride()];
     }
     constexpr Scalar& operator[](int i)

--- a/fdaPDE/src/utility/mdarray.h
+++ b/fdaPDE/src/utility/mdarray.h
@@ -86,8 +86,11 @@ template <int Idx_, typename... Slicers_> constexpr int smallest_index_in_mdarra
       is_pair_v<Slicer> && std::convertible_to<std::tuple_element_t<0, Slicer>, int> &&
       std::convertible_to<std::tuple_element_t<1, Slicer>, int>) {
         fdapde_assert(
-          std::cmp_not_equal(std::get<0>(slicer) FDAPDE_COMMA full_extent) &&
-          std::cmp_not_equal(std::get<1>(slicer) FDAPDE_COMMA full_extent));
+          std::cmp_not_equal(std::get<0>(slicer) FDAPDE_COMMA full_extent), std::invalid_argument,
+          "explicit slice start cannot be full_extent");
+        fdapde_assert(
+          std::cmp_not_equal(std::get<1>(slicer) FDAPDE_COMMA full_extent), std::invalid_argument,
+          "explicit slice end cannot be full_extent");
         return static_cast<int>(std::get<0>(slicer));
     }
 }
@@ -142,7 +145,9 @@ template <int... Extents> class MdExtents {
                 extents_[dynamic_extent_map_[j++]] = exts_[i];
             } else {
                 // check supplied extents match static, non-dynamic, ones
-                fdapde_constexpr_assert(exts_[i] == static_cast<index_t>(static_extents[i]));
+                fdapde_assert(
+                  exts_[i] == static_cast<index_t>(static_extents[i]), std::invalid_argument,
+                  "supplied extent must match the static extent");
             }
         }
     }
@@ -171,7 +176,8 @@ template <int... Extents> class MdExtents {
             if (static_extents[i] == Dynamic) {
                 extents_[dynamic_extent_map_[i]] = exts_[i];
             } else {
-                fdapde_constexpr_assert(exts_[i] == static_extents[i]);
+                fdapde_assert(
+                  exts_[i] == static_extents[i], std::invalid_argument, "supplied extent must match the static extent");
             }
         }
         return;
@@ -234,8 +240,9 @@ struct layout_left {   // corresponds to a ColMajor storage for order 2 mdarrays
         template <typename... Idxs>   // index pack to mdarray memory index
             requires(std::is_convertible_v<Idxs, index_t> && ...) && (sizeof...(Idxs) == Order)
         constexpr index_t operator()(Idxs... idx) const {
-            fdapde_constexpr_assert(
-              internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idx)...));
+            fdapde_assert(
+              internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idx)...), std::out_of_range,
+              "multidimensional index out of range");
             return internals::apply_index_pack<Order>(
               [&]<int... Ns_>() { return ((static_cast<index_t>(idx) * strides_[Ns_]) + ... + 0); });
         }
@@ -247,8 +254,8 @@ struct layout_left {   // corresponds to a ColMajor storage for order 2 mdarrays
             return idx;
         }
         constexpr index_t stride(order_t r) const requires(Order > 0) {
-            fdapde_constexpr_assert(r < Order);
-	    return strides_[r];
+            fdapde_assert(r < Order, std::out_of_range, "dimension index out of range");
+            return strides_[r];
         }
         template <typename OtherExtents>
             requires(Order == OtherExtents::Order)
@@ -292,8 +299,9 @@ struct layout_right {   // corresponds to a RowMajor storage for order 2 mdarray
         template <typename... Idxs>   // index pack to mdarray memory index
             requires(std::is_convertible_v<Idxs, index_t> && ...) && (sizeof...(Idxs) == Order)
         constexpr index_t operator()(Idxs... idx) const {
-            fdapde_constexpr_assert(
-              internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idx)...));
+            fdapde_assert(
+              internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idx)...), std::out_of_range,
+              "multidimensional index out of range");
             return internals::apply_index_pack<Order>(
               [&]<int... Ns_>() { return ((static_cast<index_t>(idx) * strides_[Ns_]) + ... + 0); });
         }
@@ -305,8 +313,8 @@ struct layout_right {   // corresponds to a RowMajor storage for order 2 mdarray
             return idx;
         }
         constexpr index_t stride(order_t r) const requires(Order > 0) {
-            fdapde_constexpr_assert(r < Order);
-	    return strides_[r];
+            fdapde_assert(r < Order, std::out_of_range, "dimension index out of range");
+            return strides_[r];
         }
         template <typename OtherExtents>
             requires(Order == OtherExtents::Order)
@@ -342,7 +350,7 @@ template <typename MdArray_, typename BlkExtents_> class MdArrayBlock {
     template <typename... Slicers>
         requires(sizeof...(Slicers) == Order && BlkExtents_::Order == MdArray_::Order) &&
                   ((internals::is_integer_v<Slicers> || internals::is_pair_v<Slicers>) && ...)
-    constexpr MdArrayBlock(MdArray_* mdarray, BlkExtents_ blk_extents, Slicers&&... slicers) noexcept :
+    constexpr MdArrayBlock(MdArray_* mdarray, BlkExtents_ blk_extents, Slicers&&... slicers) :
         extents_(blk_extents), mdarray_(mdarray) {
         internals::for_each_index_in_pack<Order>([&]<int Ns_>() mutable {
             offset_[Ns_] = internals::smallest_index_in_mdarray_blk<Ns_>(slicers...);
@@ -353,7 +361,7 @@ template <typename MdArray_, typename BlkExtents_> class MdArrayBlock {
     // observers
     constexpr size_t size() const { return extents_.size(); }
     constexpr size_t extent(order_t r) const {
-        fdapde_constexpr_assert(r < Order);
+        fdapde_assert(r < Order, std::out_of_range, "dimension index out of range");
         return extents_.extent(r);
     }
     constexpr const extents_t& extents() const { return extents_; }
@@ -438,8 +446,9 @@ template <typename MdArray_, typename BlkExtents_> class MdArrayBlock {
     template <typename... Idxs>
         requires(std::is_convertible_v<Idxs, index_t> && ...) && (sizeof...(Idxs) == BlkExtents_::Order)
     constexpr const_reference operator()(Idxs... idxs) const {
-        fdapde_constexpr_assert(
-          internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idxs)...));
+        fdapde_assert(
+          internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idxs)...), std::out_of_range,
+          "multidimensional index out of range");
         return mdarray_->operator[](internals::apply_index_pack<Order>([&]<int... Ns_>() {
             return (((static_cast<index_t>(idxs) + offset_[Ns_]) * mdarray_->mapping().stride(Ns_)) + ... + 0);
         }));
@@ -455,8 +464,9 @@ template <typename MdArray_, typename BlkExtents_> class MdArrayBlock {
         requires(std::is_convertible_v<Idxs, index_t> && ...) &&
                 (sizeof...(Idxs) == BlkExtents_::Order && !std::is_const_v<MdArray_>)
     constexpr reference operator()(Idxs... idxs) {
-        fdapde_constexpr_assert(
-          internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idxs)...));
+        fdapde_assert(
+          internals::is_multidimensional_index_in_extent(extents_, static_cast<index_t>(idxs)...), std::out_of_range,
+          "multidimensional index out of range");
         return mdarray_->operator[](internals::apply_index_pack<Order>([&]<int... Ns_>() {
             return (((static_cast<index_t>(idxs) + offset_[Ns_]) * mdarray_->mapping().stride(Ns_)) + ... + 0);
         }));
@@ -475,7 +485,9 @@ template <typename MdArray_, typename BlkExtents_> class MdArrayBlock {
           (std::is_pointer_v<Src> || internals::is_subscriptable<Src, int>) &&
           !internals::is_indexable_v<Src, Order, index_t>)
     constexpr MdArrayBlock& assign_inplace_from(Src&& src) {
-        if constexpr (!std::is_pointer_v<Src>) { fdapde_assert(src.size() == size()); }
+        if constexpr (!std::is_pointer_v<Src>) {
+            fdapde_assert(src.size() == size(), std::invalid_argument, "source size must match the destination view");
+        }
         int i = 0;
         for (reference v : *this) {
             if constexpr (std::is_same_v<Scalar, bool>) {
@@ -490,7 +502,10 @@ template <typename MdArray_, typename BlkExtents_> class MdArrayBlock {
         requires(Order == 2 && internals::is_indexable_v<Src, Order, index_t>)
     constexpr MdArrayBlock& assign_inplace_from(Src&& src) {
         fdapde_static_assert(Order == 2, THIS_METHOD_IS_FOR_ORDER_TWO_MDARRAYS_ONLY);
-        fdapde_assert(src.rows() == extent(0) && src.cols() == extent(1));
+        fdapde_assert(
+          src.rows() == extent(0), std::invalid_argument, "source row count must match the destination view");
+        fdapde_assert(
+          src.cols() == extent(1), std::invalid_argument, "source column count must match the destination view");
         for (size_t i = 0; i < extent(0); ++i) {
             for (size_t j = 0; j < extent(1); ++j) { operator()(i, j) = src(i, j); }
         }
@@ -500,7 +515,11 @@ template <typename MdArray_, typename BlkExtents_> class MdArrayBlock {
     template <typename Scalar_, typename Extents_, typename LayoutPolicy_>
         requires(std::is_same_v<Scalar_, Scalar> && Extents_::Order == Order)
     constexpr MdArrayBlock& assign_inplace_from(const MdArray<Scalar_, Extents_, LayoutPolicy_>& src) {
-        for (size_t i = 0; i < Order; ++i) { fdapde_assert(extent(i) == src.extent(i)); }
+        for (size_t i = 0; i < Order; ++i) {
+            fdapde_assert(
+              extent(i) == src.extent(i), std::invalid_argument,
+              "source extent must match the destination block extent");
+        }
         iterator jt = begin();
         for (auto it = src.begin(); it != src.end(); ++it, ++jt) { *jt = *it; }
         return *this;
@@ -534,14 +553,24 @@ constexpr auto submdarray(MdArray&& mdarray, Slicers... slicers) {
     internals::for_each_index_and_args<Order>(
       [&]<int Ns_, typename Slicer_>(Slicer_ s) {
           if constexpr (internals::is_integer_v<Slicer_>) {
-              fdapde_constexpr_assert(
-                std::cmp_equal(s FDAPDE_COMMA full_extent) ||
-                (s >= 0 && std::cmp_less(s FDAPDE_COMMA mdarray.extent(Ns_))));
+              fdapde_assert(
+                std::cmp_equal(s FDAPDE_COMMA full_extent) || s >= 0, std::out_of_range,
+                "slice index must be nonnegative or full_extent");
+              fdapde_assert(
+                std::cmp_equal(s FDAPDE_COMMA full_extent) || std::cmp_less(s FDAPDE_COMMA mdarray.extent(Ns_)),
+                std::out_of_range, "slice index out of range");
           } else if constexpr (internals::is_pair_v<Slicer_>) {
-              fdapde_constexpr_assert(
-                std::cmp_not_equal(std::get<0>(s) FDAPDE_COMMA full_extent) &&
-                std::cmp_not_equal(std::get<1>(s) FDAPDE_COMMA full_extent) && std::get<1>(s) >= std::get<0>(s) &&
-                std::cmp_less(std::get<1>(s) FDAPDE_COMMA mdarray.extent(Ns_)));
+              fdapde_assert(
+                std::cmp_not_equal(std::get<0>(s) FDAPDE_COMMA full_extent), std::invalid_argument,
+                "explicit slice start cannot be full_extent");
+              fdapde_assert(
+                std::cmp_not_equal(std::get<1>(s) FDAPDE_COMMA full_extent), std::invalid_argument,
+                "explicit slice end cannot be full_extent");
+              fdapde_assert(
+                std::get<1>(s) >= std::get<0>(s), std::invalid_argument, "slice end must not precede its start");
+              fdapde_assert(
+                std::cmp_less(std::get<1>(s) FDAPDE_COMMA mdarray.extent(Ns_)), std::out_of_range,
+                "slice end out of range");
           }
       },
       slicers...);
@@ -628,7 +657,8 @@ template <typename MdArray, int... Slicers> class MdArraySlice {
     constexpr MdArraySlice(MdArray* mdarray, Slicers_... slicers) : internal_stride_(), offset_(0), mdarray_(mdarray) {
         internals::for_each_index_and_args<sizeof...(Slicers_)>(
           [&]<int Ns_, typename Slicer__>(Slicer__ s) {
-              fdapde_constexpr_assert(std::cmp_less(s, mdarray_->extent(static_slicers[Ns_])));
+              fdapde_assert(
+                std::cmp_less(s, mdarray_->extent(static_slicers[Ns_])), std::out_of_range, "slice index out of range");
           },
           slicers...);
         // compute offset in linearized memory due to slicing
@@ -648,7 +678,7 @@ template <typename MdArray, int... Slicers> class MdArraySlice {
         return size_;
     }
     constexpr size_t extent(order_t r) const {
-        fdapde_constexpr_assert(r < Order);
+        fdapde_assert(r < Order, std::out_of_range, "dimension index out of range");
         return mdarray_->extent(free_extents_idxs_[r]);
     }
     // iterator
@@ -731,7 +761,8 @@ template <typename MdArray, int... Slicers> class MdArraySlice {
     constexpr const_reference operator()(Idxs... idxs) const {
         internals::for_each_index_and_args<Order>(
           [&]<int Ns_, typename Slicer__>(Slicer__ s) {
-              fdapde_constexpr_assert(s < mdarray_->extent(free_extents_idxs_[Ns_]));
+              fdapde_assert(
+                s < mdarray_->extent(free_extents_idxs_[Ns_]), std::out_of_range, "slice index out of range");
           },
           idxs...);
         return mdarray_->operator[](internals::apply_index_pack<Order>(
@@ -750,7 +781,9 @@ template <typename MdArray, int... Slicers> class MdArraySlice {
     constexpr reference operator()(Idxs... idxs) {
         internals::for_each_index_and_args<Order>(
           [&]<int Ns_, typename Slicer__>(Slicer__ s) {
-              fdapde_constexpr_assert(s < static_cast<index_t>(mdarray_->extent(free_extents_idxs_[Ns_])));
+              fdapde_assert(
+                s < static_cast<index_t>(mdarray_->extent(free_extents_idxs_[Ns_])), std::out_of_range,
+                "slice index out of range");
           },
           idxs...);
         return mdarray_->operator[](internals::apply_index_pack<Order>(
@@ -813,7 +846,8 @@ template <typename MdArray, int... Slicers> class MdArraySlice {
     template <typename Src>
         requires(std::is_pointer_v<Src> || internals::is_vector_like_v<Src>)
     constexpr MdArraySlice& assign_inplace_from(Src&& src) {
-        if constexpr (!std::is_pointer_v<Src>) fdapde_assert(src.size() == size());
+        if constexpr (!std::is_pointer_v<Src>)
+            fdapde_assert(src.size() == size(), std::invalid_argument, "source size must match the destination view");
         if constexpr (contiguous_access) {
             // for pointer types, this could lead to ub. is caller responsibility to guarantee bounded access
             for (int i = 0, n = size(); i < n; ++i) { operator[](i) = src[i]; }
@@ -835,7 +869,10 @@ template <typename MdArray, int... Slicers> class MdArraySlice {
           internals::is_indexable_v<Src, Order, index_t>)
     constexpr MdArraySlice& assign_inplace_from(Src&& other) {
         fdapde_static_assert(Order == 2, THIS_METHOD_IS_FOR_ORDER_TWO_MDARRAYS_ONLY);
-        fdapde_assert(other.rows() == extent(0) && other.cols() == extent(1));
+        fdapde_assert(
+          other.rows() == extent(0), std::invalid_argument, "source row count must match the destination view");
+        fdapde_assert(
+          other.cols() == extent(1), std::invalid_argument, "source column count must match the destination view");
         for (size_t i = 0; i < extent(0); ++i) {
             for (size_t j = 0; j < extent(1); ++j) { operator()(i, j) = other(i, j); }
         }
@@ -844,7 +881,7 @@ template <typename MdArray, int... Slicers> class MdArraySlice {
     template <typename MdArray_, int... Slicers_>
         requires(std::is_same_v<typename MdArray::Scalar, typename MdArray_::Scalar>)
     constexpr MdArraySlice& assign_inplace_from(const MdArraySlice<MdArray_, Slicers_...>& src) {
-        fdapde_assert(size() == src.size());
+        fdapde_assert(size() == src.size(), std::invalid_argument, "source size must match the destination view");
         for (auto it = src.begin(); it != src.end(); ++it) {
             if constexpr (std::is_same_v<Scalar, bool>) {
                 if (*it) { operator()(it.index()).set(); }
@@ -907,9 +944,10 @@ template <typename Derived> class md_handler_base {
     constexpr md_handler_base(const Extents_& extents, const Mapping_& mapping) : extents_(extents), mapping_(mapping) {
         if constexpr (extents_t::StaticOrder > 0) {
             for (int i = 0; i < extents_t::Order; ++i) {
-                fdapde_constexpr_assert(
+                fdapde_assert(
                   extents_t::static_extents[i] == Dynamic ||
-                  extents_t::static_extents[i] == Extents_::static_extents[i]);
+                    extents_t::static_extents[i] == Extents_::static_extents[i],
+                  std::invalid_argument, "supplied extent must match the static extent");
             }
         }
     }
@@ -1065,7 +1103,8 @@ template <typename Derived> class md_handler_base {
         std::array<index_t, Order> static_block_extents {Exts_...};
         internals::for_each_index_and_args<Order>(
           [&]<int Ns_, typename Slicer__>(Slicer__ s) {
-              fdapde_constexpr_assert(static_block_extents[Ns_] + s < 1 + extent(Ns_));
+              fdapde_assert(
+                static_block_extents[Ns_] + s < 1 + extent(Ns_), std::out_of_range, "slice index out of range");
           },
           slicers...);
         return MdArrayBlock<const Derived, MdExtents<Exts_...>>(
@@ -1079,7 +1118,8 @@ template <typename Derived> class md_handler_base {
         std::array<index_t, Order> static_block_extents {Exts_...};
         internals::for_each_index_and_args<Order>(
           [&]<int Ns_, typename Slicer__>(Slicer__ s) {
-              fdapde_constexpr_assert(static_block_extents[Ns_] + s < 1 + extent(Ns_));
+              fdapde_assert(
+                static_block_extents[Ns_] + s < 1 + extent(Ns_), std::out_of_range, "slice index out of range");
           },
           slicers...);
         return MdArrayBlock<Derived, MdExtents<Exts_...>>(std::addressof(derived()), MdExtents<Exts_...>(), slicers...);
@@ -1087,22 +1127,26 @@ template <typename Derived> class md_handler_base {
     // special matrix-like accessors
     constexpr auto row(index_t i) {
         fdapde_static_assert(Order == 1 || Order == 2, THIS_METHOD_IS_FOR_MATRIX_LIKE_MDARRAYS_ONLY);
-	fdapde_assert(i >= 0 && std::cmp_less(i FDAPDE_COMMA extent(0)));
+        fdapde_assert(i >= 0, std::out_of_range, "row index must be nonnegative");
+        fdapde_assert(std::cmp_less(i FDAPDE_COMMA extent(0)), std::out_of_range, "row index out of range");
         return block(i, full_extent);
     }
     constexpr auto row(index_t i) const {
         fdapde_static_assert(Order == 1 || Order == 2, THIS_METHOD_IS_FOR_MATRIX_LIKE_MDARRAYS_ONLY);
-	fdapde_assert(i >= 0 && std::cmp_less(i FDAPDE_COMMA extent(0)));
+        fdapde_assert(i >= 0, std::out_of_range, "row index must be nonnegative");
+        fdapde_assert(std::cmp_less(i FDAPDE_COMMA extent(0)), std::out_of_range, "row index out of range");
         return block(i, full_extent);
     }
     constexpr auto col(index_t i) {
         fdapde_static_assert(Order == 1 || Order == 2, THIS_METHOD_IS_FOR_MATRIX_LIKE_MDARRAYS_ONLY);
-	fdapde_assert(i >= 0 && std::cmp_less(i FDAPDE_COMMA extent(1)));
+        fdapde_assert(i >= 0, std::out_of_range, "column index must be nonnegative");
+        fdapde_assert(std::cmp_less(i FDAPDE_COMMA extent(1)), std::out_of_range, "column index out of range");
         return block(full_extent, i);
     }
     constexpr auto col(index_t i) const {
         fdapde_static_assert(Order == 1 || Order == 2, THIS_METHOD_IS_FOR_MATRIX_LIKE_MDARRAYS_ONLY);
-	fdapde_assert(i >= 0 && std::cmp_less(i FDAPDE_COMMA extent(1)));
+        fdapde_assert(i >= 0, std::out_of_range, "column index must be nonnegative");
+        fdapde_assert(std::cmp_less(i FDAPDE_COMMA extent(1)), std::out_of_range, "column index out of range");
         return block(full_extent, i);
     }
     // slicing operations
@@ -1234,7 +1278,9 @@ class MdArray : public internals::md_handler_base<MdArray<Scalar_, Extents_, Lay
 	extents_ = extents_t(static_cast<index_t>(exts)...);
 	mapping_ = mapping_t(extents_);
         data_ = callable();
-        fdapde_constexpr_assert(extents_.size() == data_.size());
+        fdapde_assert(
+          extents_.size() == data_.size(), std::invalid_argument,
+          "initializer result size must match the array extents");
     }
     // construct from other MdArray
     template <typename OtherScalar, typename OtherExtents, typename OtherLayoutPolicy>
@@ -1246,9 +1292,10 @@ class MdArray : public internals::md_handler_base<MdArray<Scalar_, Extents_, Lay
         Base(), data_(*other.data()) {
         if constexpr (extents_t::StaticOrder > 0) {
             for (order_t i = 0; i < extents_t::Order; ++i) {
-                fdapde_constexpr_assert(
+                fdapde_assert(
                   extents_t::static_extents[i] == Dynamic ||
-                  extents_t::static_extents[i] == OtherExtents::static_extents[i]);
+                    extents_t::static_extents[i] == OtherExtents::static_extents[i],
+                  std::invalid_argument, "supplied extent must match the static extent");
             }
         }
 	mapping_ = other.mapping();
@@ -1311,9 +1358,10 @@ class MdArray : public internals::md_handler_base<MdArray<Scalar_, Extents_, Lay
         if constexpr (extents_t::StaticOrder > 0) {
             for (order_t i = 0; i < slice_t::Order; ++i) {
                 order_t extent_ = slice_t::free_extents_idxs_[i];
-                fdapde_constexpr_assert(
+                fdapde_assert(
                   extents_t::static_extents[i] == Dynamic ||
-                  extents_t::static_extents[i] == OtherDerived::static_extents[slice_t::free_extents_idxs_[i]]);
+                    extents_t::static_extents[i] == OtherDerived::static_extents[slice_t::free_extents_idxs_[i]],
+                  std::invalid_argument, "supplied extent must match the static extent");
             }
         }
         if constexpr (extents_t::DynamicOrder > 0) {
@@ -1340,9 +1388,9 @@ class MdArray : public internals::md_handler_base<MdArray<Scalar_, Extents_, Lay
 	
         if constexpr (extents_t::StaticOrder > 0) {
             for (order_t i = 0; i < extents_t::Order; ++i) {
-                fdapde_constexpr_assert(
-                  extents_t::static_extents[i] == Dynamic ||
-                  extents_t::static_extents[i] == block_t::static_extents[i]);
+                fdapde_assert(
+                  extents_t::static_extents[i] == Dynamic || extents_t::static_extents[i] == block_t::static_extents[i],
+                  std::invalid_argument, "supplied extent must match the static extent");
             }
         }
         if constexpr (extents_t::DynamicOrder > 0) {
@@ -1591,9 +1639,10 @@ class MdArray<bool, Extents_, LayoutPolicy_> :
         if constexpr (extents_t::StaticOrder > 0) {
             for (order_t i = 0; i < slice_t::Order; ++i) {
                 order_t extent_ = slice_t::free_extents_idxs_[i];
-                fdapde_constexpr_assert(
+                fdapde_assert(
                   extents_t::static_extents[i] == Dynamic ||
-                  extents_t::static_extents[i] == OtherDerived::static_extents[slice_t::free_extents_idxs_[i]]);
+                    extents_t::static_extents[i] == OtherDerived::static_extents[slice_t::free_extents_idxs_[i]],
+                  std::invalid_argument, "supplied extent must match the static extent");
             }
         }
         // to avoid aliasing, first copy data, then update mapping
@@ -1621,9 +1670,9 @@ class MdArray<bool, Extents_, LayoutPolicy_> :
         using block_t = MdArrayBlock<OtherDerived, OtherBlkExtents>;
         if constexpr (extents_t::StaticOrder > 0) {
             for (order_t i = 0; i < extents_t::Order; ++i) {
-                fdapde_constexpr_assert(
-                  extents_t::static_extents[i] == Dynamic ||
-                  extents_t::static_extents[i] == block_t::static_extents[i]);
+                fdapde_assert(
+                  extents_t::static_extents[i] == Dynamic || extents_t::static_extents[i] == block_t::static_extents[i],
+                  std::invalid_argument, "supplied extent must match the static extent");
             }
         }
         // to avoid aliasing, first copy data, then update mapping

--- a/fdaPDE/src/utility/meta.h
+++ b/fdaPDE/src/utility/meta.h
@@ -235,7 +235,9 @@ template <typename T, typename... Ts> struct index_of<T, std::tuple<Ts...>> {
         int index = tuple_size;
         int i = 0;
         void(((std::is_same_v<T, Ts> ? (index = i, false) : (++i, true)) && ...));
-        fdapde_constexpr_assert(index != tuple_size);   // type not found in tuple
+        fdapde_assert(
+          index != tuple_size, std::logic_error,
+          "requested type is absent from the tuple");   // type not found in tuple
         return index;
     }
    public:

--- a/fdaPDE/src/utility/misc.h
+++ b/fdaPDE/src/utility/misc.h
@@ -51,8 +51,9 @@ template <typename Scalar, int Size> struct std_array_hash {
 template <typename V, typename W> constexpr std::unordered_map<V, W> map_reverse(const std::unordered_map<W, V>& in) {
     std::unordered_map<V, W> out;
     for (const auto& [key, value] : in) {
-        fdapde_constexpr_assert(
-          out.find(value) == out.end());   // if this is not passed, in is not a bijection, cannot be inverted
+        fdapde_assert(
+          out.find(value) == out.end(), std::invalid_argument,
+          "map inversion requires unique values");   // if this is not passed, in is not a bijection, cannot be inverted
         out[value] = key;
     }
     return out;

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -23,7 +23,7 @@ namespace fdapde {
 
 // factorial of n
 constexpr int factorial(const int n) {
-    fdapde_constexpr_assert(n >= 0);
+    fdapde_assert(n >= 0, std::domain_error, "factorial is undefined for negative integers");
     int factorial_ = 1;
     if (n == 0) return factorial_;
     int m = n;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.20)
+project(fdapde_integration_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+include(FetchContent)
+FetchContent_Declare(googletest
+  URL https://github.com/google/googletest/archive/f8d7d77c06936315286eb55f8de22cd23c188571.zip)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+find_package(Eigen3 3.4 REQUIRED NO_MODULE)
+
+enable_testing()
+include(GoogleTest)
+
+function(fdapde_configure_target target)
+  target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /W4 /WX)
+  else()
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  endif()
+endfunction()
+
+add_executable(fdapde_assert_test utility/assert.cpp)
+fdapde_configure_target(fdapde_assert_test)
+target_link_libraries(fdapde_assert_test PRIVATE GTest::gtest_main)
+gtest_discover_tests(fdapde_assert_test PROPERTIES TIMEOUT 30)
+
+# a single focused test proves disabled macro argument erasure; the suite is not duplicated
+add_executable(fdapde_assert_disabled_test utility/assert_disabled.cpp)
+fdapde_configure_target(fdapde_assert_disabled_test)
+target_compile_definitions(fdapde_assert_disabled_test PRIVATE FDAPDE_NO_DEBUG)
+target_link_libraries(fdapde_assert_disabled_test PRIVATE GTest::gtest_main)
+gtest_discover_tests(fdapde_assert_disabled_test PROPERTIES TIMEOUT 30)
+
+add_library(fdapde_core_header_check OBJECT public_headers/core.cpp)
+fdapde_configure_target(fdapde_core_header_check)
+target_link_libraries(fdapde_core_header_check PRIVATE Eigen3::Eigen)
+
+add_executable(fdapde_stable_callers_test utility/stable_callers.cpp utility/assert_callers.cpp)
+fdapde_configure_target(fdapde_stable_callers_test)
+target_link_libraries(fdapde_stable_callers_test PRIVATE GTest::gtest_main Eigen3::Eigen)
+gtest_discover_tests(fdapde_stable_callers_test PROPERTIES TIMEOUT 30)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,44 @@
+# Incremental integration tests
+
+Configure and run this stable-compatible pilot with:
+
+```sh
+cmake -S tests -B build/integration -DCMAKE_BUILD_TYPE=Debug
+cmake --build build/integration --parallel 4
+ctest --test-dir build/integration --output-on-failure
+```
+
+Requirements: C++20 compiler, CMake 3.20+, Eigen 3.4+ for stable core checks,
+and GoogleTest 1.14 (pinned source downloaded by CMake). An existing source
+checkout can be supplied through `FETCHCONTENT_SOURCE_DIR_GOOGLETEST`.
+The historical `test/` directory is retained; its disabled test includes are
+not counted as verification of this pilot.
+
+`fdapde_assert(condition, exception_type, message)` throws in debug mode;
+`FDAPDE_NO_DEBUG` removes both condition and message evaluation.
+`fdapde_strong_assert` always checks its condition. Messages are evaluated only
+on failure. `NDEBUG` alone does not disable fdaPDE assertions, so Release builds
+still exercise debug contracts unless `FDAPDE_NO_DEBUG` is explicitly set.
+The former one-argument runtime assertion is replaced. Callers use
+`std::invalid_argument` for invalid dimensions, values, and descriptors,
+`std::out_of_range` for index and name lookup failures, `std::domain_error` for
+mathematical domain violations, and `std::logic_error` for invalid object states
+and internal invariants. Independent conditions have separate diagnostics.
+The typed macro also supports constant evaluation; the one-argument constexpr
+helper remains available for compatibility.
+
+The assertion header is self-contained so execution can use the shared macros
+without pulling in the stable utility matrix implementation.
+The single `AssertionsDisabled` case is a focused exception to debug-only
+verification: argument erasure cannot be demonstrated with debug enabled.
+No ordinary suite is duplicated with `FDAPDE_NO_DEBUG`.
+
+The core header check and the grid-search/interval cases guard the migration
+of stable callers. A pre-existing unused `NaN` constant in GridSearch was
+removed to permit the strict header build; no numerical implementation changed.
+
+
+The Linux integration workflow uses GCC 14 and Clang with debug assertions and
+warnings as errors. GCC 13.3 on the Ubuntu 24.04 runner crashes inside
+`add_alignment_attribute` while emitting DWARF for the stable GeoFrame templates.
+Compiler jobs run independently so a failure in one does not cancel the other.

--- a/tests/public_headers/core.cpp
+++ b/tests/public_headers/core.cpp
@@ -1,0 +1,17 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/core.h>

--- a/tests/utility/assert.cpp
+++ b/tests/utility/assert.cpp
@@ -1,0 +1,84 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/src/utility/assert.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+// verifies exception type, exact message and single evaluation on failed debug checks
+TEST(Assertions, DebugFailurePreservesExceptionAndMessage) {
+    int conditions = 0;
+    int messages = 0;
+    try {
+        fdapde_assert(++conditions == 0, std::invalid_argument, (++messages, "invalid input"));
+        // reaching this line means the false condition did not throw
+        FAIL() << "debug assertion did not throw";
+    } catch (const std::invalid_argument& error) {
+        // compares the exception payload with the supplied message
+        EXPECT_STREQ(error.what(), "invalid input");
+    }
+    // counts one evaluation of the condition
+    EXPECT_EQ(conditions, 1);
+    // counts one construction of the failure message
+    EXPECT_EQ(messages, 1);
+}
+
+// verifies lazy messages on success and safe use within an unbraced if/else
+TEST(Assertions, SuccessfulChecksAreSingleStatementsWithLazyMessages) {
+    int conditions = 0;
+    int messages = 0;
+    if (true)
+        fdapde_assert(++conditions == 1, std::logic_error, (++messages, "unused"));
+    else
+        ++messages;
+    if (true)
+        fdapde_strong_assert(++conditions == 2, std::logic_error, (++messages, "unused"));
+    else
+        ++messages;
+    // checks that each successful primitive evaluated its condition once
+    EXPECT_EQ(conditions, 2);
+    // detects eager message evaluation or incorrect else binding
+    EXPECT_EQ(messages, 0);
+}
+
+// verifies permanent checks preserve the user-selected exception payload
+TEST(Assertions, StrongFailurePreservesExceptionAndMessage) {
+    try {
+        fdapde_strong_assert(false, std::out_of_range, std::string("outside domain"));
+        // a permanent false check must not reach the next statement
+        FAIL() << "strong assertion did not throw";
+    } catch (const std::out_of_range& error) {
+        // compares the exact message carried by the requested exception type
+        EXPECT_STREQ(error.what(), "outside domain");
+    }
+}
+
+namespace {
+/// @brief exercises the retained constexpr helper in constant and runtime evaluation
+constexpr int checked_value(int value) {
+    fdapde_constexpr_assert(value > 0);
+    return value;
+}
+}   // namespace
+
+// verifies the legacy helper remains usable by stable constexpr callers
+TEST(Assertions, ConstexprHelperChecksRuntimeFailures) {
+    // constant evaluation must accept a satisfied precondition
+    static_assert(checked_value(3) == 3);
+    // runtime evaluation must throw the helper's documented logic_error
+    EXPECT_THROW(checked_value(0), std::logic_error);
+}

--- a/tests/utility/assert_callers.cpp
+++ b/tests/utility/assert_callers.cpp
@@ -1,0 +1,189 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/core.h>
+#include <gtest/gtest.h>
+
+#include <typeinfo>
+
+namespace {
+/// @brief checks the exact exception type and diagnostic produced by a failed contract
+template <typename Exception, typename Callable> void expect_failure(Callable&& call, const char* message) {
+    try {
+        call();
+        // a rejected operation must throw before returning to the caller
+        FAIL() << "operation did not throw";
+    } catch (const Exception& error) {
+        // checks the concrete type so a generic logic_error cannot hide a classification regression
+        EXPECT_EQ(typeid(error), typeid(Exception));
+        // checks which independent precondition rejected the operation
+        EXPECT_STREQ(error.what(), message);
+    }
+}
+}   // namespace
+
+// verifies row and column bounds produce distinct diagnostics through mutable and const views
+TEST(AssertionCallers, ArrayIndicesIdentifyTheFailingAxis) {
+    fdapde::MdArray<int, fdapde::MdExtents<fdapde::Dynamic, fdapde::Dynamic>> data(2, 3);
+    const auto& const_data = data;
+    // checks the lower row bound before creating a mutable view
+    expect_failure<std::out_of_range>([&] { data.row(-1); }, "row index must be nonnegative");
+    // checks the upper row bound before creating a mutable view
+    expect_failure<std::out_of_range>([&] { data.row(2); }, "row index out of range");
+    // checks the lower column bound before creating a mutable view
+    expect_failure<std::out_of_range>([&] { data.col(-1); }, "column index must be nonnegative");
+    // checks the upper column bound before creating a mutable view
+    expect_failure<std::out_of_range>([&] { data.col(3); }, "column index out of range");
+    // verifies the const overload preserves the row diagnostic
+    expect_failure<std::out_of_range>([&] { const_data.row(2); }, "row index out of range");
+    // verifies the const overload preserves the column diagnostic
+    expect_failure<std::out_of_range>([&] { const_data.col(3); }, "column index out of range");
+    // confirms valid boundary indices still allow access
+    EXPECT_NO_THROW(data(1, 2) = 7);
+}
+
+// verifies binary operations report row and column mismatches separately
+TEST(AssertionCallers, BinaryOperandsIdentifyTheMismatchedDimension) {
+    fdapde::BinaryMatrix<fdapde::Dynamic, fdapde::Dynamic> lhs(2, 3), wrong_rows(3, 3), wrong_cols(2, 4);
+    // rejects a row mismatch without requiring a column mismatch
+    expect_failure<std::invalid_argument>([&] { (void)(lhs | wrong_rows); }, "operand row counts must match");
+    // reaches the column check after the row check succeeds
+    expect_failure<std::invalid_argument>([&] { (void)(lhs | wrong_cols); }, "operand column counts must match");
+    // verifies binary matrix access is classified as an index failure
+    expect_failure<std::out_of_range>([&] { lhs.set(2, 0); }, "row index out of range");
+    // verifies the column access check has its own diagnostic
+    expect_failure<std::out_of_range>([&] { lhs.set(0, 3); }, "column index out of range");
+}
+
+// verifies spline indices and construction arguments use different exception categories
+TEST(AssertionCallers, SplineChecksSeparateIndexOrderAndKnotCount) {
+    std::vector<double> knots {0, 1, 2};
+    // rejects an invalid index before evaluating the remaining constructor checks
+    expect_failure<std::out_of_range>([&] { fdapde::Spline spline(knots, -1, 1); }, "spline index must be nonnegative");
+    // identifies a negative polynomial order as an invalid argument
+    expect_failure<std::invalid_argument>(
+      [&] { fdapde::Spline spline(knots, 0, -1); }, "spline order must be nonnegative");
+    // identifies a knot vector too short for the requested order
+    expect_failure<std::invalid_argument>(
+      [&] { fdapde::Spline spline(knots, 0, 3); }, "knot count must exceed the spline order");
+    // reaches the upper index check after the other arguments pass
+    expect_failure<std::out_of_range>(
+      [&] { fdapde::Spline spline(knots, 3, 1); }, "spline index exceeds the knot vector");
+    // confirms valid construction remains accepted
+    EXPECT_NO_THROW(fdapde::Spline(knots, 0, 1));
+}
+
+// verifies mesh construction reports each malformed input independently before geometric assembly
+TEST(AssertionCallers, TriangulationChecksSeparateInputShapes) {
+    Eigen::MatrixXd nodes(3, 2);
+    nodes << 0, 0, 1, 0, 0, 1;
+    Eigen::MatrixXi cells(1, 3), boundary = Eigen::MatrixXi::Ones(3, 1);
+    cells << 0, 1, 2;
+    auto construct = [](const Eigen::MatrixXd& n, const Eigen::MatrixXi& c, const Eigen::MatrixXi& b) {
+        fdapde::Triangulation<2, 2> mesh(n, c, b);
+    };
+    // the empty-node check must run before checks that use node coordinates
+    expect_failure<std::invalid_argument>(
+      [&] { construct(Eigen::MatrixXd(0, 2), cells, boundary); }, "triangulation nodes must not be empty");
+    // reaches the coordinate dimension check with a nonempty node matrix
+    expect_failure<std::invalid_argument>(
+      [&] { construct(Eigen::MatrixXd(3, 1), cells, boundary); },
+      "node coordinate dimension must match the embedding dimension");
+    // an empty cell matrix must fail before minCoeff is evaluated
+    expect_failure<std::invalid_argument>(
+      [&] { construct(nodes, Eigen::MatrixXi(0, 3), boundary); }, "triangulation cells must not be empty");
+    // reaches the cell width check with a nonempty cell matrix
+    expect_failure<std::invalid_argument>(
+      [&] { construct(nodes, Eigen::MatrixXi(1, 2), boundary); }, "cell width must match the number of nodes per cell");
+    // identifies an incorrect number of boundary markers
+    expect_failure<std::invalid_argument>(
+      [&] { construct(nodes, cells, Eigen::MatrixXi(2, 1)); }, "boundary marker count must match the number of nodes");
+    // identifies an incorrect boundary marker orientation
+    expect_failure<std::invalid_argument>(
+      [&] { construct(nodes, cells, Eigen::MatrixXi(3, 2)); }, "boundary markers must form a column vector");
+    // confirms the valid inputs still produce a mesh
+    EXPECT_NO_THROW(construct(nodes, cells, boundary));
+}
+
+// verifies invalid marker values are distinct from missing marker initialization
+TEST(AssertionCallers, CellFilteringSeparatesArgumentsFromObjectState) {
+    fdapde::Triangulation<1, 1> interval(0.0, 1.0, 3);
+    // a negative marker other than the all-cells sentinel is an invalid argument
+    expect_failure<std::invalid_argument>(
+      [&] { interval.cells_begin(-3); }, "cell marker must be nonnegative or TriangulationAll");
+    // a valid marker cannot be used before marker storage is initialized
+    expect_failure<std::logic_error>(
+      [&] { interval.cells_begin(1); }, "cell markers must be initialized before filtering");
+    // the sentinel bypasses marker initialization for both iterator endpoints
+    EXPECT_NO_THROW({
+        interval.cells_begin();
+        interval.cells_end();
+    });
+}
+
+// verifies argument exceptions propagate through constructors instead of terminating in noexcept
+TEST(AssertionCallers, CheckedConstructorsPropagateExceptions) {
+    Eigen::SparseMatrix<double> rectangular(2, 3), empty(0, 0);
+    // checks that the factorization constructor propagates its shape diagnostic
+    expect_failure<std::invalid_argument>(
+      [&] { fdapde::FSPAI<Eigen::SparseMatrix<double>> factor(rectangular); }, "FSPAI requires a square matrix");
+    // reaches the nonempty check after the square-matrix check succeeds
+    expect_failure<std::invalid_argument>(
+      [&] { fdapde::FSPAI<Eigen::SparseMatrix<double>> factor(empty); }, "FSPAI requires a nonempty matrix");
+    // verifies polygon construction propagates an invalid argument to its caller
+    expect_failure<std::invalid_argument>(
+      [] { fdapde::Polygon<2, 2> polygon(Eigen::MatrixXd(0, 2)); }, "polygon nodes must not be empty");
+    fdapde::Triangulation<1, 1> interval;
+    // verifies geometric assembly helpers also propagate constructor checks
+    expect_failure<std::invalid_argument>(
+      [&] { fdapde::CellDiameter diameter(interval); }, "triangulation must contain nodes");
+}
+
+// verifies constexpr-capable callers retain compile-time use and classify runtime failures
+TEST(AssertionCallers, ConstantEvaluationAndRuntimeExceptionTypesAgree) {
+    // evaluates the successful mathematical operation at compile time
+    static_assert(fdapde::factorial(5) == 120);
+    // distinguishes an undefined mathematical input from an index or shape error
+    expect_failure<std::domain_error>(
+      [] { (void)fdapde::factorial(-1); }, "factorial is undefined for negative integers");
+    // checks the typed replacement of a constexpr matrix constructor precondition
+    expect_failure<std::invalid_argument>(
+      [] { fdapde::Matrix<double, 2, 2> matrix(std::vector<double>(3)); },
+      "coefficient count must match the matrix size");
+}
+
+// verifies name lookup failures are classified like keyed container access
+TEST(AssertionCallers, MissingColumnsThrowOutOfRange) {
+    fdapde::internals::scalar_data_layer data;
+    // a missing named column must fail before constructing a column view
+    expect_failure<std::out_of_range>([&] { data.col<double>("missing"); }, "column name not found");
+    // a missing column used by the null mask has the same lookup category
+    expect_failure<std::out_of_range>([&] { data.nan(std::string("missing")); }, "column name not found");
+}
+
+// verifies the dot product checks both output dimensions instead of comparing a row count with itself
+TEST(AssertionCallers, DotProductChecksBothOperandDimensions) {
+    using Field = fdapde::MatrixField<2, fdapde::Dynamic, fdapde::Dynamic>;
+    Field lhs(2, 2, 3), wrong_rows(2, 3, 3), wrong_cols(2, 2, 4);
+    // rejects unequal row counts even when column counts match
+    expect_failure<std::invalid_argument>(
+      [&] { (void)fdapde::dot(lhs, wrong_rows); }, "dot product row counts must match");
+    // reports the column mismatch independently
+    expect_failure<std::invalid_argument>(
+      [&] { (void)fdapde::dot(lhs, wrong_cols); }, "dot product column counts must match");
+    // confirms equal operand shapes still pass construction
+    EXPECT_NO_THROW((void)fdapde::dot(lhs, lhs));
+}

--- a/tests/utility/assert_disabled.cpp
+++ b/tests/utility/assert_disabled.cpp
@@ -1,0 +1,39 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// this single focused exception to debug-only testing proves argument erasure
+#include <fdaPDE/src/utility/assert.h>
+#include <gtest/gtest.h>
+
+// verifies disabled arguments are neither evaluated nor required to be valid C++ expressions
+TEST(AssertionsDisabled, ErasesDebugArgumentsAndKeepsStrongChecks) {
+    int evaluations = 0;
+    fdapde_assert(++evaluations == 0, std::logic_error, (++evaluations, "unused"));
+    fdapde_assert(undefined_condition(), UndefinedException, undefined_message());
+    fdapde_constexpr_assert(undefined_constexpr_condition());
+    // an unchanged counter proves that both disabled arguments were skipped
+    EXPECT_EQ(evaluations, 0);
+    try {
+        fdapde_strong_assert(++evaluations == 0, std::invalid_argument, "always active");
+        // a disabled debug mode must not suppress the permanent assertion
+        FAIL() << "strong assertion did not throw";
+    } catch (const std::invalid_argument& error) {
+        // checks the exact permanent failure message with debug disabled
+        EXPECT_STREQ(error.what(), "always active");
+    }
+    // the permanent condition still runs exactly once
+    EXPECT_EQ(evaluations, 1);
+}

--- a/tests/utility/stable_callers.cpp
+++ b/tests/utility/stable_callers.cpp
@@ -1,0 +1,45 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/core.h>
+#include <gtest/gtest.h>
+
+// verifies migrated checks still support stable multidimensional grid evaluation
+TEST(StableCallers, GridSearchKeepsMatrixLayoutAndRejectsWrongDimension) {
+    fdapde::GridSearch<2> search;
+    Eigen::Matrix<double, 3, 2> grid;
+    grid << 4, 2, 1, 3, 2, 1;
+    auto objective = [](const Eigen::Vector2d& point) -> double { return point.squaredNorm(); };
+    auto optimum = search.optimize(objective, grid);
+    // compares both coordinates with the unique minimum row in the input grid
+    EXPECT_TRUE(optimum.isApprox(Eigen::Vector2d(2, 1)));
+    // checks the numerical objective at the selected row
+    EXPECT_DOUBLE_EQ(search.value(), 5.0);
+    // instantiates a migrated constructor failure through the public stable API
+    EXPECT_THROW(fdapde::GridSearch<2>(3), std::invalid_argument);
+}
+
+// verifies geometry and its binary markers instantiate with the migrated assertion signature
+TEST(StableCallers, IntervalPreservesNodesAndRejectsEmptyInput) {
+    fdapde::Triangulation<1, 1> interval(0.0, 1.0, 5);
+    // checks that construction retained all requested nodes
+    EXPECT_EQ(interval.n_nodes(), 5);
+    // checks that consecutive nodes form four intervals
+    EXPECT_EQ(interval.n_cells(), 4);
+    Eigen::VectorXd empty;
+    // an empty coordinate vector must fail the migrated debug precondition
+    EXPECT_THROW((fdapde::Triangulation<1, 1>(empty)), std::invalid_argument);
+}


### PR DESCRIPTION
This PR replaces process-terminating assertions with typed exceptions and separates debug-only checks from checks that remain enabled in every build.

- Introduces `fdapde_assert(condition, exception_type, message)` and `fdapde_strong_assert(condition, exception_type, message)`. Messages are evaluated only on failure, and both macros work safely in unbraced `if/else` statements.
- Classifies caller failures: `std::invalid_argument` for invalid inputs, `std::out_of_range` for index and name lookup failures, `std::domain_error` for mathematical domain violations, and `std::logic_error` for invalid object states and internal invariants.
- Splits independent preconditions into separate assertions with specific diagnostics. Updates constexpr callers to use the typed macro while retaining the one-argument helper for compatibility.
- Allows checked constructors to propagate exceptions, validates triangulation input before converting boundary markers, and fixes the dot product row check that compared a dimension with itself.
- Adds caller-contract regressions, strict public-header compilation, and a two-compiler CI workflow. Removes an unused GridSearch constant and an extra Spline constructor semicolon required for strict builds.

Validation: all 16 tests pass with AppleClang 21 in Debug, GCC 15.2 in Release, and GCC 14.2 and Clang 18.1 on Ubuntu 24.04. [Successful Linux CI run](https://github.com/fdaPDE/fdaPDE-core/actions/runs/34371382430). The caller regressions verify concrete exception types and exact diagnostics for dimensions, indices, spline arguments, mesh inputs, object state, named columns, and constexpr operations. The core header compiles as C++20 with `-Wall -Wextra -Wpedantic -Werror`.

`FDAPDE_NO_DEBUG` removes both condition and message evaluation from debug assertions. Strong assertions remain active; `NDEBUG` alone does not disable fdaPDE assertions. External callers of the old runtime macro must adopt the three-argument signature.

CI uses GCC 14 because GCC 13.3 encounters an internal compiler error while emitting GeoFrame debug information. Compiler jobs run independently, retaining Debug mode and strict warnings. The tests do not provide complete downstream coverage.
