### PR TITLE
Fix scalar numeric errors and add constexpr support

### DIFF
--- a/docs/numeric-utilities.md
+++ b/docs/numeric-utilities.md
@@ -1,0 +1,39 @@
+# Numeric utilities
+
+Include `<fdaPDE/utility.h>` to use scalar utilities in runtime code and C++20 constant expressions. Dense matrix types and Eigen-backed modules retain their existing public headers.
+
+```cpp
+#include <fdaPDE/utility.h>
+
+static_assert(fdapde::sqrt(1e-20) > 0.99999999999999e-10);
+static_assert(fdapde::min(2, 1.5) == 1.5);
+static_assert(fdapde::ldexp(0.75f, 3) == 6.0f);
+```
+
+`sqrt` supports floating-point scalars, preserves signed zero and positive infinity, and returns NaN for negative arguments or NaN. Runtime evaluation uses `std::sqrt`; constant evaluation normalizes the input before Heron's iteration.
+
+`frexp` decomposes a `double` into a signed fraction and binary exponent. Finite nonzero fractions have magnitude in `[0.5, 1)`, including subnormal inputs. Zero and nonfinite arguments are returned unchanged with exponent zero. Runtime finite decomposition uses `std::frexp`.
+
+`ldexp` scales a floating-point scalar by an integer power of two. It supports `float`, `double`, and `long double`, preserves signed zero and nonfinite inputs, and handles subnormal results and exponents wider than `int`. Runtime evaluation uses `std::ldexp` after bounding the exponent. Constant evaluation normalizes first and rounds subnormal results once at the final multiplication.
+
+`log` returns positive infinity for positive infinity, negative infinity for either signed zero, and NaN for negative arguments or NaN. Finite `log` and `exp` use polynomial approximations rather than correctly rounded implementations. Tests bound the logarithm's absolute error by `1e-9` at the listed representative scales; they do not establish a uniform error bound over every floating-point input. `log1p` and `log1pexp` compose these approximations, with separate branches for small or large arguments.
+
+`pow` accepts integer exponents, including the minimum signed exponent and wide integer exponents. As with built-in arithmetic, intermediate overflow limits constant evaluation. `min` and `max` promote their arguments to a common type and participate only when the corresponding scalar comparison is valid.
+
+The existing comparison conventions remain unchanged: `sign(x)` reports nonnegativity as zero or one; `greater_equal` and `less_equal` compare a difference against relative tolerance and therefore exclude equal nonzero values at the default positive tolerance. The strict `greater_than` and `less_than` helpers remain available to existing consumers. Integer division requires a nonzero divisor; factorial and combinations are limited by their integer result range. `ceil` and `floor` require inputs whose integral part fits in `long`.
+
+Expression nesting metadata remains internal. `ref_select` preserves the declared `NestAsRef` policy; it does not itself establish lifetime safety for temporary owning expressions.
+
+# Verification
+
+From the repository root:
+
+```sh
+cmake -S tests -B build/numeric-debug -DCMAKE_BUILD_TYPE=Debug
+cmake --build build/numeric-debug --parallel
+ctest --test-dir build/numeric-debug --output-on-failure
+```
+
+The tests cover numeric constant evaluation and runtime boundaries, nesting traits, Eigen vector dispatch, stable dense expressions, KD-tree boundary queries, and analytic P1 finite-element mass assembly. Compile targets check `utility.h`, `linear_algebra.h`, and `core.h` independently. Debug assertions stay enabled in the numeric tests, including CMake Release builds. The pre-existing focused disabled-assert test is separate.
+
+For GCC on the macOS SDK whose Mach headers use `_Static_assert` in C++, configure with `-DCMAKE_CXX_FLAGS=-D_Static_assert=static_assert`. This is a toolchain workaround, not a change to fdaPDE assertion behavior. Sanitizer builds can use `-DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer'` with Clang.

--- a/fdaPDE/src/utility/meta.h
+++ b/fdaPDE/src/utility/meta.h
@@ -22,6 +22,22 @@
 namespace fdapde {
 namespace internals {
 
+// if XprType has either its NestAsRef bit set or is dynamic sized, sets type member type to XprType&,
+// otherwise to XprType
+template <typename XprType, bool has_ref_bit> struct ref_select_impl;
+template <typename XprType> struct ref_select_impl<XprType, true> {
+   private:
+    using XprTypeClean = std::decay_t<XprType>;
+   public:
+    using type = std::conditional_t<
+      XprTypeClean::NestAsRef == 0, std::remove_reference_t<XprType>, std::add_lvalue_reference_t<XprType>>;
+};
+template <typename XprType> struct ref_select_impl<XprType, false> : std::type_identity<XprType> { };
+template <typename XprType> struct ref_select {
+    using type = ref_select_impl<XprType, requires(XprType) { XprType::NestAsRef; }>::type;
+};
+template <typename XprType> using ref_select_t = typename ref_select<XprType>::type;
+  
 // apply lambda F_ to each value in index pack {0, ..., N_ - 1}
 template <int N_, typename F_> constexpr decltype(auto) apply_index_pack(F_&& f) {
     return [&]<int... Ns_>(std::integer_sequence<int, Ns_...>) -> decltype(auto) {
@@ -324,21 +340,6 @@ struct fn_ptr_traits_impl<R (T::*)(Args...) const> : public fn_ptr_traits_base<R
     using MemFnPtrType = R (T::*)(Args...) const;
 };
 template <auto FnPtr> struct fn_ptr_traits : public fn_ptr_traits_impl<decltype(FnPtr)> { };
-
-// if XprType has its NestAsRef bit set, returns the type XprType&, otherwise return XprType.
-template <typename XprType>
-concept has_nest_as_ref_bit = requires(XprType t) { XprType::NestAsRef; };
-
-template <typename XprType, bool v> struct ref_select_impl;
-template <typename XprType> struct ref_select_impl<XprType, true> {
-    using type = std::conditional_t<
-      XprType::NestAsRef == 0, std::remove_reference_t<XprType>, std::add_lvalue_reference_t<XprType>>;
-};
-template <typename XprType> struct ref_select_impl<XprType, false> {
-    using type = XprType;
-};
-template <typename XprType> struct ref_select : ref_select_impl<XprType, has_nest_as_ref_bit<XprType>> { };
-template <typename XprType> using ref_select_t = ref_select<XprType>::type;
 
 // selects one between arg1 and arg2 based on condition f
 template <typename Arg1, typename Arg2, typename F>

--- a/fdaPDE/src/utility/meta.h
+++ b/fdaPDE/src/utility/meta.h
@@ -22,9 +22,9 @@
 namespace fdapde {
 namespace internals {
 
-// if XprType has either its NestAsRef bit set or is dynamic sized, sets type member type to XprType&,
-// otherwise to XprType
+/// @brief selects expression storage according to its NestAsRef flag
 template <typename XprType, bool has_ref_bit> struct ref_select_impl;
+/// @brief uses the declared nesting policy of an expression
 template <typename XprType> struct ref_select_impl<XprType, true> {
    private:
     using XprTypeClean = std::decay_t<XprType>;
@@ -32,12 +32,14 @@ template <typename XprType> struct ref_select_impl<XprType, true> {
     using type = std::conditional_t<
       XprTypeClean::NestAsRef == 0, std::remove_reference_t<XprType>, std::add_lvalue_reference_t<XprType>>;
 };
+/// @brief preserves types without an expression nesting flag
 template <typename XprType> struct ref_select_impl<XprType, false> : std::type_identity<XprType> { };
+/// @brief dispatches storage selection for an expression type
 template <typename XprType> struct ref_select {
     using type = ref_select_impl<XprType, requires(XprType) { XprType::NestAsRef; }>::type;
 };
 template <typename XprType> using ref_select_t = typename ref_select<XprType>::type;
-  
+
 // apply lambda F_ to each value in index pack {0, ..., N_ - 1}
 template <int N_, typename F_> constexpr decltype(auto) apply_index_pack(F_&& f) {
     return [&]<int... Ns_>(std::integer_sequence<int, Ns_...>) -> decltype(auto) {
@@ -107,10 +109,9 @@ template <typename... Ts> struct is_tuple<std::tuple<Ts...>> : std::true_type { 
 template <typename T1, typename T2>   // std::pair detected as tuple instance
 struct is_tuple<std::pair<T1, T2>> : std::true_type { };
 template <typename T> static constexpr bool is_tuple_v = is_tuple<std::decay_t<T>>::value;
-  
+
 // detect if T is a pair-like object
-template <typename T>
-struct is_pair {
+template <typename T> struct is_pair {
     static constexpr bool value = []() {
         if constexpr (is_tuple_v<std::decay_t<T>>) {
             if constexpr (std::tuple_size_v<std::decay_t<T>> == 2) {
@@ -127,13 +128,13 @@ template <typename T> static constexpr bool is_pair_v = is_pair<T>::value;
 
 // detect if T is a shared_ptr instance
 template <typename T> struct is_shared_ptr : std::false_type { };
-template <typename T> struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
+template <typename T> struct is_shared_ptr<std::shared_ptr<T>> : std::true_type { };
 template <typename T> static constexpr bool is_shared_ptr_v = is_shared_ptr<T>::value;
-  // given a type E, returns T if E = std::shared_ptr<T>, or directly returns E otherwise
+// given a type E, returns T if E = std::shared_ptr<T>, or directly returns E otherwise
 template <typename E> struct remove_shared_ptr {
     using type = decltype([]() {
-      if constexpr (is_shared_ptr_v<std::decay_t<E>>) {
-          return typename E::element_type();
+        if constexpr (is_shared_ptr_v<std::decay_t<E>>) {
+            return typename E::element_type();
         } else {
             return E();
         }
@@ -169,7 +170,7 @@ template <typename T, int Order, typename IndexT> class is_indexable {
 };
 template <typename T, int Order, typename IndexT>
 static constexpr bool is_indexable_v = is_indexable<T, Order, IndexT>::value;
-  
+
 // detects if T behaves like a vector
 template <typename T> class is_vector_like {
     using T_ = std::decay_t<T>;
@@ -198,15 +199,15 @@ decltype(auto) vector_like_access(T&& data, int index) {
         return data(index);
     }
 }
-  
+
 // detect if T behaves like a matrix
 template <typename T> class is_matrix_like {
     using T_ = std::decay_t<T>;
-  public:
-   static constexpr bool value = internals::is_indexable_v<T_, 2, int> && requires(T_ t) {
-       { t.rows() } -> std::convertible_to<int>;
-       { t.cols() } -> std::convertible_to<int>;
-   };
+   public:
+    static constexpr bool value = internals::is_indexable_v<T_, 2, int> && requires(T_ t) {
+        { t.rows() } -> std::convertible_to<int>;
+        { t.cols() } -> std::convertible_to<int>;
+    };
 };
 template <typename T> static constexpr bool is_matrix_like_v = is_matrix_like<T>::value;
 
@@ -215,7 +216,7 @@ template <int N, typename... Ts>
     requires(sizeof...(Ts) >= N)
 struct pack_element : std::type_identity<std::tuple_element_t<N, std::tuple<Ts...>>> { };
 template <int N, typename... Ts> using pack_element_t = typename pack_element<N, Ts...>::type;
-  
+
 // detect whether there are no duplicate types in pack
 template <typename... Ts> struct unique;
 template <typename T1, typename T2, typename... Ts> struct unique<T1, T2, Ts...> {
@@ -234,7 +235,7 @@ template <typename T, typename T1, typename... Ts> struct all_same<T, T1, Ts...>
 };
 template <typename T> struct all_same<T> : std::true_type { };
 template <typename T, typename... Ts> static constexpr bool all_same_v = all_same<T, Ts...>::value;
-  
+
 // detect wheter all types in pack are equal
 template <typename... Ts> struct all_equal;
 template <typename T1, typename... Ts> struct all_equal<T1, Ts...> {
@@ -258,7 +259,7 @@ template <typename T, typename... Ts> struct index_of<T, std::tuple<Ts...>> {
     }
    public:
     static constexpr int value = find_idx(std::index_sequence_for<Ts...> {});
-};  
+};
 
 // returns std::true_type if tuple contains type T
 template <typename T, typename Tuple> struct has_type { };
@@ -320,7 +321,7 @@ template <typename SwitchCase> struct switch_type<SwitchCase> {   // end of recu
     fdapde_static_assert(SwitchCase::value, NO_TRUE_CONDITION_IN_SWITCH_TYPE_STATEMENT);
     using type = typename SwitchCase::type;
 };
-  
+
 // member function pointers trait
 template <typename F> struct fn_ptr_traits_base { };
 template <typename R, typename T, typename... Args> struct fn_ptr_traits_base<R (T::*)(Args...)> {
@@ -328,7 +329,7 @@ template <typename R, typename T, typename... Args> struct fn_ptr_traits_base<R 
     using ArgsType = std::tuple<Args...>;
     static constexpr int n_args = sizeof...(Args);
     using ClassType = T;
-    using FnPtrType = R (*)(void*, Args&&...);    // void* is the pointer to the object instance
+    using FnPtrType = R (*)(void*, Args&&...);   // void* is the pointer to the object instance
 };
 template <typename F> struct fn_ptr_traits_impl { };
 template <typename R, typename T, typename... Args>
@@ -377,7 +378,7 @@ template <typename T, typename W> struct prefer_most_derived {
     using type = std::conditional_t<std::is_same_v<T, W>, T, std::conditional_t<std::is_base_of_v<T, W>, W, T>>;
 };
 template <typename T, typename W> using prefer_most_derived_t = typename prefer_most_derived<T, W>::type;
-  
+
 }   // namespace internals
 }   // namespace fdapde
 

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -71,14 +71,14 @@ constexpr std::common_type_t<T1, T2> int_floor(T1 a, T2 b) {
 }
 
 // min function with common type conversion
-template <typename T1, typename T2> std::common_type_t<T1, T2> min(T1 a, T2 b) {
+template <typename T1, typename T2> constexpr std::common_type_t<T1, T2> min(T1 a, T2 b) {
     using T = std::common_type_t<T1, T2>;
-    return std::min<T>(static_cast<T>(a), static_cast<T>(b));
+    return (static_cast<T>(a) <= static_cast<T>(b)) ? static_cast<T>(a) : static_cast<T>(b);
 }
 // max function with common type conversion
-template <typename T1, typename T2> std::common_type_t<T1, T2> max(T1 a, T2 b) {
+template <typename T1, typename T2> constexpr std::common_type_t<T1, T2> max(T1 a, T2 b) {
     using T = std::common_type_t<T1, T2>;
-    return std::max<T>(static_cast<T>(a), static_cast<T>(b));
+    return (static_cast<T>(a) >= static_cast<T>(b)) ? static_cast<T>(a) : static_cast<T>(b);
 }
 
 // constexpr absoulte value

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -21,7 +21,7 @@
 
 namespace fdapde {
 
-// factorial of n
+/// @brief factorial of n
 constexpr int factorial(const int n) {
     fdapde_assert(n >= 0, std::domain_error, "factorial is undefined for negative integers");
     int factorial_ = 1;
@@ -33,12 +33,12 @@ constexpr int factorial(const int n) {
     }
     return factorial_;
 }
-// binomial coefficient n over m
+/// @brief binomial coefficient n over m
 constexpr int binomial_coefficient(const int n, const int m) {
     if (m == 0 || n == m) return 1;
     return factorial(n) / (factorial(m) * factorial(n - m));
 }
-// binomial_coefficient(n, k) x k matrix of combinations of k elements from a set of n
+/// @brief binomial_coefficient(n, k) x k matrix of combinations of k elements from a set of n
 constexpr std::vector<int> combinations(int k, int n) {
     std::vector<bool> bitmask(k, 1);
     bitmask.resize(n, 0);
@@ -57,20 +57,20 @@ constexpr std::vector<int> combinations(int k, int n) {
     return result;
 }
 
-// integer division with round up
+/// @brief integer division with round up
 template <typename T1, typename T2>
     requires(internals::is_integer_v<T1> && internals::is_integer_v<T2>)
 constexpr std::common_type_t<T1, T2> int_ceil(T1 a, T2 b) {
     return ((a ^ b) >= 0) ? a / b + (a % b != 0) : a / b;
 }
-// integer division with round down
+/// @brief integer division with round down
 template <typename T1, typename T2>
     requires(internals::is_integer_v<T1> && internals::is_integer_v<T2>)
 constexpr std::common_type_t<T1, T2> int_floor(T1 a, T2 b) {
     return ((a ^ b) < 0 && a % b != 0) ? a / b - 1 : a / b;
 }
 
-// min function with common type conversion
+/// @brief min function with common type conversion
 template <typename T1, typename T2>
     requires requires(T1 a, T2 b) {
         (static_cast<std::common_type_t<T1, T2>>(a) <= static_cast<std::common_type_t<T1, T2>>(b)) ? 0 : 0;
@@ -79,7 +79,7 @@ constexpr std::common_type_t<T1, T2> min(T1 a, T2 b) {
     using T = std::common_type_t<T1, T2>;
     return (static_cast<T>(a) <= static_cast<T>(b)) ? static_cast<T>(a) : static_cast<T>(b);
 }
-// max function with common type conversion
+/// @brief max function with common type conversion
 template <typename T1, typename T2>
     requires requires(T1 a, T2 b) {
         (static_cast<std::common_type_t<T1, T2>>(a) >= static_cast<std::common_type_t<T1, T2>>(b)) ? 0 : 0;
@@ -89,40 +89,73 @@ constexpr std::common_type_t<T1, T2> max(T1 a, T2 b) {
     return (static_cast<T>(a) >= static_cast<T>(b)) ? static_cast<T>(a) : static_cast<T>(b);
 }
 
-// constexpr absoulte value
-template <typename T> requires(std::is_arithmetic_v<T>) constexpr T abs(T x) { return x < 0 ? -x : x; }
-template <typename T> requires(std::is_floating_point_v<T>) constexpr T fabs(T x) { return x < 0 ? -x : x; }
-  
-// test for floating point equality
+/// @brief constexpr absolute value
+template <typename T>
+    requires(std::is_arithmetic_v<T>)
+constexpr T abs(T x) {
+    return x < 0 ? -x : x;
+}
+/// @brief returns the absolute floating-point value
+template <typename T>
+    requires(std::is_floating_point_v<T>)
+constexpr T fabs(T x) {
+    return x < 0 ? -x : x;
+}
+
+/// @brief test for floating point equality
 [[maybe_unused]] constexpr double double_tolerance = 1e-10;
-[[maybe_unused]] constexpr double machine_epsilon  = 50 * std::numeric_limits<double>::epsilon();   // approx 10^-14
+[[maybe_unused]] constexpr double machine_epsilon = 50 * std::numeric_limits<double>::epsilon();   // approx 10^-14
+/// @brief compares values with absolute and relative tolerance
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr bool almost_equal(T a, T b, T epsilon) {
     return fdapde::fabs(a - b) < epsilon ||
            fdapde::fabs(a - b) < ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
 }
+/// @brief compares values with absolute and relative tolerance
 template <typename T> constexpr bool almost_equal(T a, T b) { return almost_equal(a, b, double_tolerance); }
+/// @brief checks a non-strict difference against relative tolerance
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr bool greater_equal(T a, T b, T epsilon) {
     return (a - b) >= ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
 }
+/// @brief checks a non-strict difference against relative tolerance
 template <typename T> constexpr bool greater_equal(T a, T b) { return greater_equal(a, b, double_tolerance); }
+/// @brief checks a reversed non-strict difference against relative tolerance
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr bool less_equal(T a, T b, T epsilon) {
     return (b - a) >= ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
 }
+/// @brief checks a reversed non-strict difference against relative tolerance
 template <typename T> constexpr bool less_equal(T a, T b) { return less_equal(a, b, double_tolerance); }
+/// @brief checks a strict difference against relative tolerance
+template <typename T>
+    requires(std::is_floating_point_v<T>)
+constexpr bool greater_than(T a, T b, T epsilon) {
+    return (a - b) > ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
+}
+/// @brief checks a strict difference against relative tolerance
+template <typename T> constexpr bool greater_than(T a, T b) { return greater_than(a, b, double_tolerance); }
+/// @brief checks a reversed strict difference against relative tolerance
+template <typename T>
+    requires(std::is_floating_point_v<T>)
+constexpr bool less_than(T a, T b, T epsilon) {
+    return (b - a) > ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
+}
+/// @brief checks a reversed strict difference against relative tolerance
+template <typename T> constexpr bool less_than(T a, T b) { return less_than(a, b, double_tolerance); }
+/// @brief checks absolute magnitude against a tolerance
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr bool almost_zero(T a, T epsilon) {
     return fdapde::fabs(a) < epsilon;
 }
+/// @brief checks absolute magnitude against a tolerance
 template <typename T> constexpr bool almost_zero(T a) { return almost_zero(a, machine_epsilon); }
 
-// constexpr square root
+/// @brief constexpr square root
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr T sqrt(T x) {
@@ -130,7 +163,7 @@ constexpr T sqrt(T x) {
     if (!(x > T(0))) return std::numeric_limits<T>::quiet_NaN();
     if (!std::is_constant_evaluated()) return std::sqrt(x);
 
-    // Scale into [1,4) so Heron's iteration is safe at both ends of the floating-point range.
+    // scale into [1,4) so Heron's iteration is safe at both ends of the floating-point range
     T scale = T(1);
     while (x < T(1)) {
         x *= T(4);
@@ -148,21 +181,21 @@ constexpr T sqrt(T x) {
     return curr * scale;
 }
 
-// constexpr ceil
+/// @brief constexpr ceil
 template <typename T> constexpr std::conditional_t<std::is_floating_point_v<T>, T, double> ceil(T x) {
     long int int_part = static_cast<long int>(x);
     return (x > 0.0 && x != static_cast<T>(int_part)) ? int_part + 1.0 : int_part;
 }
-// constexpr floor
+/// @brief constexpr floor
 template <typename T> constexpr std::conditional_t<std::is_floating_point_v<T>, T, double> floor(T x) {
     long int int_part = static_cast<long int>(x);
     return (x < 0.0 && x != static_cast<T>(int_part)) ? int_part - 1.0 : int_part;
 }
 
-// constexpr sign function
+/// @brief returns one for nonnegative inputs and zero otherwise
 template <typename T> constexpr int sign(T x) { return x >= 0 ? 1 : 0; }
 
-// constexpr pow, only integer exponent support
+/// @brief constexpr pow, only integer exponent support
 template <typename BaseT, typename ExpT>
     requires(std::is_floating_point_v<BaseT> && internals::is_integer_v<ExpT>)
 constexpr BaseT pow(BaseT base, ExpT exp) {
@@ -179,47 +212,48 @@ constexpr BaseT pow(BaseT base, ExpT exp) {
     return exp < 0 ? BaseT {1} / result : result;
 }
 
-// constexpr ldexp, computes num * 2^exp
+/// @brief constexpr ldexp, computes num * 2^exp
 template <typename BaseT, typename ExpT>
     requires(std::is_floating_point_v<BaseT> && internals::is_integer_v<ExpT>)
 constexpr BaseT ldexp(BaseT num, ExpT exp) {
-    if (num == 0.0) return num;  // preserve signed zero
-    if (num != num) return std::numeric_limits<double>::quiet_NaN();
-    if (num == std::numeric_limits<double>::infinity() || num == -std::numeric_limits<double>::infinity())
-        return num;
+    using Limits = std::numeric_limits<BaseT>;
+    if (num == BaseT(0) || num != num || fdapde::abs(num) == Limits::infinity()) return num;
+    constexpr int exponent_bound = Limits::max_exponent - Limits::min_exponent + Limits::digits;
+    if (std::cmp_greater(+exp, exponent_bound)) return num < 0 ? -Limits::infinity() : Limits::infinity();
+    if (std::cmp_less(+exp, -exponent_bound)) return num < 0 ? -BaseT(0) : BaseT(0);
+    int exponent = static_cast<int>(exp);
+    if (!std::is_constant_evaluated()) return std::ldexp(num, exponent);
 
-    constexpr std::uint64_t SIGN_MASK = 0x8000000000000000ULL;
-    constexpr std::uint64_t EXP_MASK  = 0x7FF0000000000000ULL;
-    constexpr std::uint64_t MANT_MASK = 0x000FFFFFFFFFFFFFULL;
-
-    auto u = std::bit_cast<std::uint64_t>(num);   // recover bit representation of num
-    int exponent = static_cast<int>((u & EXP_MASK) >> 52);
-    std::uint64_t mantissa = u & MANT_MASK;
-    std::uint64_t sign = u & SIGN_MASK;
-
-    if (exponent == 0) {   // subnormal number
-        while ((mantissa & (1ULL << 52)) == 0) {
-            mantissa <<= 1;
-            exponent--;
-        }
-        mantissa &= MANT_MASK;
-        exponent++;
+    // normalize exactly before scaling to avoid intermediate overflow and repeated subnormal rounding
+    while (fdapde::abs(num) >= BaseT(1)) {
+        num *= BaseT(0.5);
+        ++exponent;
     }
-    if (exponent == 0x7FF) { return num; }   // NaN/inf
-    exponent += exp;
-    if (exponent <= 0) { return sign ? -0.0 : 0.0; }   // underflow
-    if (exponent >= 0x7FF) {                           // overflow
-        return sign ? -std::numeric_limits<double>::infinity() : std::numeric_limits<double>::infinity();
+    while (fdapde::abs(num) < BaseT(0.5)) {
+        num *= BaseT(2);
+        --exponent;
     }
-    // reconstruct IEEE 753 representation
-    return std::bit_cast<double>(sign | ((static_cast<std::uint64_t>(exponent) << 52) & EXP_MASK) | mantissa);
+    if (exponent > Limits::max_exponent) return num < 0 ? -Limits::infinity() : Limits::infinity();
+    if (exponent < Limits::min_exponent - Limits::digits) return num < 0 ? -BaseT(0) : BaseT(0);
+    BaseT scale = BaseT(1);
+    if (exponent < Limits::min_exponent) {
+        // form subnormal results with a single final rounding at the minimum normal scale
+        for (int i = exponent; i < Limits::min_exponent - 1; ++i) num *= BaseT(0.5);
+        return num * Limits::min();
+    }
+    if (exponent > 0) {
+        for (int i = 1; i < exponent; ++i) scale *= BaseT(2);
+        return (num * BaseT(2)) * scale;
+    }
+    for (int i = 0; i > exponent; --i) scale *= BaseT(0.5);
+    return num * scale;
 }
 
-// constexpr exp
+/// @brief approximates the exponential with a reduced Taylor polynomial
 constexpr double exp(double x) {
-    constexpr double ln2    = 0.69314718055994530941723212145817656;   // ln(2)
+    constexpr double ln2 = 0.69314718055994530941723212145817656;      // ln(2)
     constexpr double invln2 = 1.44269504088896340735992468100189214;   // 1/ln(2)
-    // polynomial coefficients for exp(r) Taylor's expansion on [-ln2/2, ln2/2]
+    // polynomial coefficients for the reduced exponential Taylor expansion
     constexpr double C1 = 1.0;
     constexpr double C2 = 1.0;                         // 1
     constexpr double C3 = 0.5;                         // 1/2
@@ -229,20 +263,20 @@ constexpr double exp(double x) {
     constexpr double C7 = 1.38888888888888894189e-3;   // 1/720
 
     if (x != x) return std::numeric_limits<double>::quiet_NaN();
-    if (x >  709.782712893384) return std::numeric_limits<double>::infinity();
+    if (x > 709.782712893384) return std::numeric_limits<double>::infinity();
     if (x < -745.133219101941) return 0.0;
     // reduction
     int k = static_cast<int>(x * invln2 + sign(x) * 0.5);
     double r = x - k * ln2;
-    // Talyor expansion evaluation by horner
+    // evaluate the Taylor polynomial using Horner's method
     double R = ((((((C7 * r + C6) * r + C5) * r + C4) * r + C3) * r + C2) * r + C1);
     return ldexp(R, k);
 };
 
-// constexpr ilogb: integer log2 of |x|: floor(\log_2(|x|))
+/// @brief constexpr ilogb: integer log2 of |x|: floor(\log_2(|x|))
 constexpr int ilogb(double x) {
-    if (x == 0.0) return std::numeric_limits<int>::min();   // FP_ILOGB0
-    if (x != x)   return std::numeric_limits<int>::max();   // FP_ILOGBNAN
+    if (x == 0.0) return std::numeric_limits<int>::min();   // fP_ILOGB0
+    if (x != x) return std::numeric_limits<int>::max();     // fP_ILOGBNAN
 
     std::uint64_t bits = std::bit_cast<std::uint64_t>(x < 0 ? -x : x);   // recover bit expression
     int exp = static_cast<int>((bits >> 52) & 0x7FF);
@@ -257,7 +291,7 @@ constexpr int ilogb(double x) {
     return exp - 1023;   // remove IEEE bias
 }
 
-// constexpr frexp: x = fraction * 2^out, with |fraction| in [0.5,1) for finite nonzero x.
+/// @brief constexpr frexp: x = fraction * 2^out, with |fraction| in [0.5,1) for finite nonzero x
 constexpr double frexp(double x, int& out) {
     out = 0;
     if (x == 0.0 || x != x || fdapde::abs(x) == std::numeric_limits<double>::infinity()) return x;
@@ -273,7 +307,7 @@ constexpr double frexp(double x, int& out) {
     return x;
 }
 
-// constexpr log (inspired from fdlibm)
+/// @brief approximates the natural logarithm with a polynomial inspired by fdlibm
 constexpr double log(double x) {
     // constants split for accuracy
     constexpr double ln2_hi = 6.93147180369123816490e-01;
@@ -297,13 +331,13 @@ constexpr double log(double x) {
     double f = m - 1.0;   // in [-0.5,0)
     double s = f / (2.0 + f);
     double z = s * s;
-    // approximate log(1 + z) for small f, with z = s * s, s = f/(2 + f). Perform Horner evaluation of taylor expansion
-    double R = z*(Lg1 + z*(Lg2 + z*(Lg3 + z*(Lg4 + z*(Lg5 + z*(Lg6 + z*Lg7))))));
+    // evaluate the reduced logarithm polynomial using Horner's method
+    double R = z * (Lg1 + z * (Lg2 + z * (Lg3 + z * (Lg4 + z * (Lg5 + z * (Lg6 + z * Lg7))))));
     double hfsq = 0.5 * f * f;
     return k * ln2_hi - ((hfsq - (s * (hfsq + R) + k * ln2_lo)) - f);
 }
 
-// constexpr log1p
+/// @brief constexpr log1p
 constexpr double log1p(double x) {
     if (x == 0.0) { return 0.0; }
     if (x == -1.0) { return -std::numeric_limits<double>::infinity(); }   // log(0)
@@ -316,20 +350,19 @@ constexpr double log1p(double x) {
         double x4 = x3 * x;
         return x - 0.5 * x2 + x3 / 3.0 - x4 / 4.0;
     }
-    return fdapde::log(1.0 + x);   // fallback to standard log
+    return fdapde::log(1.0 + x);
 }
 
-// numerical stable log(1 + exp(x)) computation (see "Machler, M. (2012). Accurately computing log(1-exp(-|a|))")
+/// @brief computes log(1 + exp(x)) with range-dependent approximations to avoid overflow
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr T log1pexp(T x) {
     if (x <= -37.0) return fdapde::exp(x);
-    if (x <=  18.0) return fdapde::log1p(fdapde::exp(x));
-    if (x >   33.3) return x;
+    if (x <= 18.0) return fdapde::log1p(fdapde::exp(x));
+    if (x > 33.3) return x;
     return x + fdapde::exp(-x);
 }
 
-  
 }   // namespace fdapde
 
 #endif   // __FDAPDE_NUMERIC_H__

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -110,16 +110,6 @@ constexpr bool almost_zero(T a, T epsilon) {
 }
 template <typename T> constexpr bool almost_zero(T a) { return almost_zero(a, machine_epsilon); }
 
-// numerical stable log(1 + exp(x)) computation (see "Machler, M. (2012). Accurately computing log(1-exp(-|a|))")
-template <typename T>
-    requires(std::is_floating_point_v<T>)
-constexpr T log1pexp(T x) {
-    if (x <= -37.0) return std::exp(x);
-    if (x <=  18.0) return std::log1p(std::exp(x));
-    if (x >   33.3) return x;
-    return x + std::exp(-x);
-}
-
 // constexpr absoulte value
 template <typename T> requires(std::is_signed_v<T>) constexpr T abs(T x) { return x < 0 ? -x : x; }
 
@@ -149,6 +139,9 @@ template <typename T> constexpr std::conditional_t<std::is_floating_point_v<T>, 
     return (x < 0.0 && x != static_cast<T>(int_part)) ? int_part - 1.0 : int_part;
 }
 
+// constexpr sign function
+template <typename T> constexpr int sign(T x) { return x >= 0 ? 1 : 0; }
+
 // constexpr pow, only integer exponent support
 template <typename BaseT, typename ExpT>
     requires(std::is_floating_point_v<BaseT> && internals::is_integer_v<ExpT>)
@@ -164,6 +157,158 @@ constexpr BaseT pow(BaseT base, ExpT exp) {
     return exp < 0 ? BaseT {1} / result : result;
 }
 
+// constexpr ldexp, computes num * 2^exp
+template <typename BaseT, typename ExpT>
+    requires(std::is_floating_point_v<BaseT> && internals::is_integer_v<ExpT>)
+constexpr BaseT ldexp(BaseT num, ExpT exp) {
+    if (num == 0.0) return num;  // preserve signed zero
+    if (num != num) return std::numeric_limits<double>::quiet_NaN();
+    if (num == std::numeric_limits<double>::infinity() || num == -std::numeric_limits<double>::infinity())
+        return num;
+
+    constexpr std::uint64_t SIGN_MASK = 0x8000000000000000ULL;
+    constexpr std::uint64_t EXP_MASK  = 0x7FF0000000000000ULL;
+    constexpr std::uint64_t MANT_MASK = 0x000FFFFFFFFFFFFFULL;
+
+    auto u = std::bit_cast<std::uint64_t>(num);   // recover bit representation of num
+    int exponent = static_cast<int>((u & EXP_MASK) >> 52);
+    std::uint64_t mantissa = u & MANT_MASK;
+    std::uint64_t sign = u & SIGN_MASK;
+
+    if (exponent == 0) {   // subnormal number
+        while ((mantissa & (1ULL << 52)) == 0) {
+            mantissa <<= 1;
+            exponent--;
+        }
+        mantissa &= MANT_MASK;
+        exponent++;
+    }
+    if (exponent == 0x7FF) { return num; }   // NaN/inf
+    exponent += exp;
+    if (exponent <= 0) { return sign ? -0.0 : 0.0; }   // underflow
+    if (exponent >= 0x7FF) {                           // overflow
+        return sign ? -std::numeric_limits<double>::infinity() : std::numeric_limits<double>::infinity();
+    }
+    // reconstruct IEEE 753 representation
+    return std::bit_cast<double>(sign | ((static_cast<std::uint64_t>(exponent) << 52) & EXP_MASK) | mantissa);
+}
+
+// constexpr exp
+constexpr double exp(double x) {
+    constexpr double ln2    = 0.69314718055994530941723212145817656;   // ln(2)
+    constexpr double invln2 = 1.44269504088896340735992468100189214;   // 1/ln(2)
+    // polynomial coefficients for exp(r) Taylor's expansion on [-ln2/2, ln2/2]
+    constexpr double C1 = 1.0;
+    constexpr double C2 = 1.0;                         // 1
+    constexpr double C3 = 0.5;                         // 1/2
+    constexpr double C4 = 1.66666666666666657415e-1;   // 1/6
+    constexpr double C5 = 4.16666666666666643537e-2;   // 1/24
+    constexpr double C6 = 8.33333333333333321769e-3;   // 1/120
+    constexpr double C7 = 1.38888888888888894189e-3;   // 1/720
+
+    if (x != x) return std::numeric_limits<double>::quiet_NaN();
+    if (x >  709.782712893384) return std::numeric_limits<double>::infinity();
+    if (x < -745.133219101941) return 0.0;
+    // reduction
+    int k = static_cast<int>(x * invln2 + sign(x) * 0.5);
+    double r = x - k * ln2;
+    // Talyor expansion evaluation by horner
+    double R = ((((((C7 * r + C6) * r + C5) * r + C4) * r + C3) * r + C2) * r + C1);
+    return ldexp(R, k);
+};
+
+// constexpr ilogb: integer log2 of |x|: floor(\log_2(|x|))
+constexpr int ilogb(double x) {
+    if (x == 0.0) return std::numeric_limits<int>::min();   // FP_ILOGB0
+    if (x != x)   return std::numeric_limits<int>::max();   // FP_ILOGBNAN
+
+    std::uint64_t bits = std::bit_cast<std::uint64_t>(x < 0 ? -x : x);   // recover bit expression
+    int exp = static_cast<int>((bits >> 52) & 0x7FF);
+    if (exp == 0) {   // subnormal
+        int shift = 0;
+        while ((bits & (1ULL << 52)) == 0) {
+            bits <<= 1;
+            ++shift;
+        }
+        return -1022 - shift + 1;
+    }
+    return exp - 1023;   // remove IEEE bias
+}
+
+// constexpr frexp: scales x's mantissa in range [0.5,1), store exponent in out such that x * 2^exp = num
+constexpr double frexp(double x, int& out) {
+    if (x == 0.0) {
+        out = 0;
+        return 0.0;
+    }
+    std::uint64_t bits = std::bit_cast<std::uint64_t>(x);   // reover bit expression
+    int exp = static_cast<int>((bits >> 52) & 0x7FF);
+    if (exp == 0) {   // subnormal
+        while ((bits & (1ULL << 52)) == 0) bits <<= 1;
+        exp = 1;
+    }
+    out = exp - 1022;  // force mantissa into [0.5,1)
+
+    // mask exponent and replace with 1022 (0x3FE)
+    return std::bit_cast<double>((bits & ((1ULL << 52) - 1)) | (0x3FEULL << 52));
+}
+
+// constexpr log (inspired from fdlibm)
+constexpr double log(double x) {
+    // constants split for accuracy
+    constexpr double ln2_hi = 6.93147180369123816490e-01;
+    constexpr double ln2_lo = 1.90821492927058770002e-10;
+    // polynomial coefficients (credits: fdlibm)
+    constexpr double Lg1 = 6.666666666666735130e-01;
+    constexpr double Lg2 = 3.999999999940941908e-01;
+    constexpr double Lg3 = 2.857142874366239149e-01;
+    constexpr double Lg4 = 2.222219843214978396e-01;
+    constexpr double Lg5 = 1.818357216161805012e-01;
+    constexpr double Lg6 = 1.531383769920937332e-01;
+    constexpr double Lg7 = 1.479819860511658591e-01;
+
+    if (x < 0.0 || x != x) { return std::numeric_limits<double>::quiet_NaN(); }
+    if (x == 0.0 || x == std::numeric_limits<double>::infinity()) { return -std::numeric_limits<double>::infinity(); }
+    // decompose
+    int k;
+    double m = fdapde::frexp(x, k);   // x = m * 2^k, m in [0.5,1)
+    // range reduction
+    double f = m - 1.0;   // in [-0.5,0)
+    double s = f / (2.0 + f);
+    double z = s * s;
+    // approximate log(1 + z) for small f, with z = s * s, s = f/(2 + f). Perform Horner evaluation of taylor expansion
+    double R = z*(Lg1 + z*(Lg2 + z*(Lg3 + z*(Lg4 + z*(Lg5 + z*(Lg6 + z*Lg7))))));
+    double hfsq = 0.5 * f * f;
+    return k * ln2_hi - ((hfsq - (s * (hfsq + R) + k * ln2_lo)) - f);
+}
+
+// constexpr log1p
+constexpr double log1p(double x) {
+    if (x == 0.0) { return 0.0; }
+    if (x == -1.0) { return -std::numeric_limits<double>::infinity(); }   // log(0)
+    if (x < -1.0) { return std::numeric_limits<double>::quiet_NaN(); }    // log of negative value
+
+    // for small x, use series expansion
+    if (x > -1e-8 && x < 1e-8) {
+        double x2 = x * x;
+        double x3 = x2 * x;
+        double x4 = x3 * x;
+        return x - 0.5 * x2 + x3 / 3.0 - x4 / 4.0;
+    }
+    return fdapde::log(1.0 + x);   // fallback to standard log
+}
+
+// numerical stable log(1 + exp(x)) computation (see "Machler, M. (2012). Accurately computing log(1-exp(-|a|))")
+template <typename T>
+    requires(std::is_floating_point_v<T>)
+constexpr T log1pexp(T x) {
+    if (x <= -37.0) return fdapde::exp(x);
+    if (x <=  18.0) return fdapde::log1p(fdapde::exp(x));
+    if (x >   33.3) return x;
+    return x + fdapde::exp(-x);
+}
+
+  
 }   // namespace fdapde
 
 #endif   // __FDAPDE_NUMERIC_H__

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -81,37 +81,38 @@ template <typename T1, typename T2> std::common_type_t<T1, T2> max(T1 a, T2 b) {
     return std::max<T>(static_cast<T>(a), static_cast<T>(b));
 }
 
+// constexpr absoulte value
+template <typename T> requires(std::is_arithmetic_v<T>) constexpr T abs(T x) { return x < 0 ? -x : x; }
+template <typename T> requires(std::is_floating_point_v<T>) constexpr T fabs(T x) { return x < 0 ? -x : x; }
+  
 // test for floating point equality
 [[maybe_unused]] constexpr double double_tolerance = 1e-10;
 [[maybe_unused]] constexpr double machine_epsilon  = 50 * std::numeric_limits<double>::epsilon();   // approx 10^-14
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr bool almost_equal(T a, T b, T epsilon) {
-    return std::fabs(a - b) < epsilon ||
-           std::fabs(a - b) < ((std::fabs(a) < std::fabs(b) ? std::fabs(b) : std::fabs(a)) * epsilon);
+    return fdapde::fabs(a - b) < epsilon ||
+           fdapde::fabs(a - b) < ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
 }
 template <typename T> constexpr bool almost_equal(T a, T b) { return almost_equal(a, b, double_tolerance); }
 template <typename T>
     requires(std::is_floating_point_v<T>)
-constexpr bool greater_than(T a, T b, T epsilon) {
-    return (a - b) > ((std::fabs(a) < std::fabs(b) ? std::fabs(b) : std::fabs(a)) * epsilon);
+constexpr bool greater_equal(T a, T b, T epsilon) {
+    return (a - b) >= ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
 }
-template <typename T> constexpr bool greater_than(T a, T b) { return greater_than(a, b, double_tolerance); }
+template <typename T> constexpr bool greater_equal(T a, T b) { return greater_equal(a, b, double_tolerance); }
 template <typename T>
     requires(std::is_floating_point_v<T>)
-constexpr bool less_than(T a, T b, T epsilon) {
-    return (b - a) > ((std::fabs(a) < std::fabs(b) ? std::fabs(b) : std::fabs(a)) * epsilon);
+constexpr bool less_equal(T a, T b, T epsilon) {
+    return (b - a) >= ((fdapde::fabs(a) < fdapde::fabs(b) ? fdapde::fabs(b) : fdapde::fabs(a)) * epsilon);
 }
-template <typename T> constexpr bool less_than(T a, T b) { return less_than(a, b, double_tolerance); }
+template <typename T> constexpr bool less_equal(T a, T b) { return less_equal(a, b, double_tolerance); }
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr bool almost_zero(T a, T epsilon) {
-    return std::fabs(a) < epsilon;
+    return fdapde::fabs(a) < epsilon;
 }
 template <typename T> constexpr bool almost_zero(T a) { return almost_zero(a, machine_epsilon); }
-
-// constexpr absoulte value
-template <typename T> requires(std::is_signed_v<T>) constexpr T abs(T x) { return x < 0 ? -x : x; }
 
 // constexpr square root
 template <typename T>

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -71,12 +71,20 @@ constexpr std::common_type_t<T1, T2> int_floor(T1 a, T2 b) {
 }
 
 // min function with common type conversion
-template <typename T1, typename T2> constexpr std::common_type_t<T1, T2> min(T1 a, T2 b) {
+template <typename T1, typename T2>
+    requires requires(T1 a, T2 b) {
+        (static_cast<std::common_type_t<T1, T2>>(a) <= static_cast<std::common_type_t<T1, T2>>(b)) ? 0 : 0;
+    }
+constexpr std::common_type_t<T1, T2> min(T1 a, T2 b) {
     using T = std::common_type_t<T1, T2>;
     return (static_cast<T>(a) <= static_cast<T>(b)) ? static_cast<T>(a) : static_cast<T>(b);
 }
 // max function with common type conversion
-template <typename T1, typename T2> constexpr std::common_type_t<T1, T2> max(T1 a, T2 b) {
+template <typename T1, typename T2>
+    requires requires(T1 a, T2 b) {
+        (static_cast<std::common_type_t<T1, T2>>(a) >= static_cast<std::common_type_t<T1, T2>>(b)) ? 0 : 0;
+    }
+constexpr std::common_type_t<T1, T2> max(T1 a, T2 b) {
     using T = std::common_type_t<T1, T2>;
     return (static_cast<T>(a) >= static_cast<T>(b)) ? static_cast<T>(a) : static_cast<T>(b);
 }

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -148,7 +148,9 @@ template <typename BaseT, typename ExpT>
     requires(std::is_floating_point_v<BaseT> && internals::is_integer_v<ExpT>)
 constexpr BaseT pow(BaseT base, ExpT exp) {
     if (exp == 0) return BaseT {1};
-    unsigned int abs_exp = static_cast<unsigned int>((exp < 0) ? -exp : exp);
+    using UnsignedExp = std::make_unsigned_t<std::remove_cvref_t<ExpT>>;
+    const UnsignedExp unsigned_exp = static_cast<UnsignedExp>(exp);
+    UnsignedExp abs_exp = exp < 0 ? UnsignedExp {0} - unsigned_exp : unsigned_exp;
     BaseT result = BaseT {1};
     while (abs_exp > 0) {
         if (abs_exp % 2 == 1) result *= base;

--- a/fdaPDE/src/utility/numeric.h
+++ b/fdaPDE/src/utility/numeric.h
@@ -126,15 +126,26 @@ template <typename T> constexpr bool almost_zero(T a) { return almost_zero(a, ma
 template <typename T>
     requires(std::is_floating_point_v<T>)
 constexpr T sqrt(T x) {
-    auto heron_method = [](T x) {
-        T curr = x, prev = 0;
-        while (fdapde::abs(curr - prev) > machine_epsilon) {
-            prev = curr;
-            curr = 0.5 * (curr + x / curr);
-        }
-        return curr;
-    };
-    return x >= 0 && x < std::numeric_limits<T>::infinity() ? heron_method(x) : std::numeric_limits<T>::quiet_NaN();
+    if (x == T(0) || x == std::numeric_limits<T>::infinity()) return x;
+    if (!(x > T(0))) return std::numeric_limits<T>::quiet_NaN();
+    if (!std::is_constant_evaluated()) return std::sqrt(x);
+
+    // Scale into [1,4) so Heron's iteration is safe at both ends of the floating-point range.
+    T scale = T(1);
+    while (x < T(1)) {
+        x *= T(4);
+        scale *= T(0.5);
+    }
+    while (x >= T(4)) {
+        x *= T(0.25);
+        scale *= T(2);
+    }
+    T curr = x, prev = T(0);
+    while (fdapde::abs(curr - prev) > std::numeric_limits<T>::epsilon() * curr) {
+        prev = curr;
+        curr = T(0.5) * (curr + x / curr);
+    }
+    return curr * scale;
 }
 
 // constexpr ceil
@@ -246,22 +257,20 @@ constexpr int ilogb(double x) {
     return exp - 1023;   // remove IEEE bias
 }
 
-// constexpr frexp: scales x's mantissa in range [0.5,1), store exponent in out such that x * 2^exp = num
+// constexpr frexp: x = fraction * 2^out, with |fraction| in [0.5,1) for finite nonzero x.
 constexpr double frexp(double x, int& out) {
-    if (x == 0.0) {
-        out = 0;
-        return 0.0;
+    out = 0;
+    if (x == 0.0 || x != x || fdapde::abs(x) == std::numeric_limits<double>::infinity()) return x;
+    if (!std::is_constant_evaluated()) return std::frexp(x, &out);
+    while (fdapde::abs(x) >= 1.0) {
+        x *= 0.5;
+        ++out;
     }
-    std::uint64_t bits = std::bit_cast<std::uint64_t>(x);   // reover bit expression
-    int exp = static_cast<int>((bits >> 52) & 0x7FF);
-    if (exp == 0) {   // subnormal
-        while ((bits & (1ULL << 52)) == 0) bits <<= 1;
-        exp = 1;
+    while (fdapde::abs(x) < 0.5) {
+        x *= 2.0;
+        --out;
     }
-    out = exp - 1022;  // force mantissa into [0.5,1)
-
-    // mask exponent and replace with 1022 (0x3FE)
-    return std::bit_cast<double>((bits & ((1ULL << 52) - 1)) | (0x3FEULL << 52));
+    return x;
 }
 
 // constexpr log (inspired from fdlibm)
@@ -279,7 +288,8 @@ constexpr double log(double x) {
     constexpr double Lg7 = 1.479819860511658591e-01;
 
     if (x < 0.0 || x != x) { return std::numeric_limits<double>::quiet_NaN(); }
-    if (x == 0.0 || x == std::numeric_limits<double>::infinity()) { return -std::numeric_limits<double>::infinity(); }
+    if (x == 0.0) { return -std::numeric_limits<double>::infinity(); }
+    if (x == std::numeric_limits<double>::infinity()) { return x; }
     // decompose
     int k;
     double m = fdapde::frexp(x, k);   // x = m * 2^k, m in [0.5,1)

--- a/fdaPDE/utility.h
+++ b/fdaPDE/utility.h
@@ -22,6 +22,8 @@
 // STL includes
 #include <utility>
 #include <algorithm>
+#include <bit>
+#include <cstdint>
 #include <cmath>
 #include <functional>
 #include <iostream>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,19 @@ add_library(fdapde_core_header_check OBJECT public_headers/core.cpp)
 fdapde_configure_target(fdapde_core_header_check)
 target_link_libraries(fdapde_core_header_check PRIVATE Eigen3::Eigen)
 
-add_executable(fdapde_stable_callers_test utility/stable_callers.cpp utility/assert_callers.cpp)
+add_executable(fdapde_stable_callers_test utility/stable_callers.cpp utility/assert_callers.cpp utility/numeric_callers.cpp)
 fdapde_configure_target(fdapde_stable_callers_test)
 target_link_libraries(fdapde_stable_callers_test PRIVATE GTest::gtest_main Eigen3::Eigen)
 gtest_discover_tests(fdapde_stable_callers_test PROPERTIES TIMEOUT 30)
+
+add_executable(fdapde_numeric_test utility/numeric.cpp utility/meta.cpp)
+fdapde_configure_target(fdapde_numeric_test)
+target_link_libraries(fdapde_numeric_test PRIVATE GTest::gtest_main)
+gtest_discover_tests(fdapde_numeric_test PROPERTIES TIMEOUT 30)
+
+add_library(fdapde_utility_header_check OBJECT public_headers/utility.cpp)
+fdapde_configure_target(fdapde_utility_header_check)
+
+add_library(fdapde_linear_algebra_header_check OBJECT public_headers/linear_algebra.cpp)
+fdapde_configure_target(fdapde_linear_algebra_header_check)
+target_link_libraries(fdapde_linear_algebra_header_check PRIVATE Eigen3::Eigen)

--- a/tests/public_headers/linear_algebra.cpp
+++ b/tests/public_headers/linear_algebra.cpp
@@ -1,0 +1,17 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/linear_algebra.h>

--- a/tests/public_headers/utility.cpp
+++ b/tests/public_headers/utility.cpp
@@ -1,0 +1,17 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/utility.h>

--- a/tests/utility/meta.cpp
+++ b/tests/utility/meta.cpp
@@ -1,0 +1,116 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/utility.h>
+#include <gtest/gtest.h>
+
+namespace {
+/// @brief models an expression that retains its owner by reference
+struct owner_expression {
+    static constexpr int NestAsRef = 1;
+};
+/// @brief models an expression node copied into its parent
+struct value_expression {
+    static constexpr int NestAsRef = 0;
+};
+}   // namespace
+
+// verifies storage selection preserves constness and the declared nesting policy
+TEST(NumericFoundation, ExpressionNestingTraits) {
+    using namespace fdapde::internals;
+    // verifies mutable owners are stored by reference
+    static_assert(std::is_same_v<ref_select_t<owner_expression>, owner_expression&>);
+    // verifies const owners remain const when nested
+    static_assert(std::is_same_v<ref_select_t<const owner_expression>, const owner_expression&>);
+    // verifies value nodes are copied with their cv qualification
+    static_assert(std::is_same_v<ref_select_t<const value_expression>, const value_expression>);
+    // verifies types without a nesting flag retain their original reference category
+    static_assert(std::is_same_v<ref_select_t<int&>, int&>);
+    // verifies value nodes supplied as references keep the existing no-flag-lookup behavior
+    static_assert(std::is_same_v<ref_select_t<value_expression&>, value_expression&>);
+}
+
+// verifies scalar helpers remain usable in constant expressions with mixed arithmetic types
+TEST(NumericFoundation, ScalarHelpers) {
+    // verifies min promotes both arguments before selecting the smaller value
+    static_assert(fdapde::min(2, 1.5) == 1.5);
+    // verifies max preserves a promoted floating-point result
+    static_assert(fdapde::max(2, 1.5) == 2.0);
+    // verifies positive integer division rounds upward
+    static_assert(fdapde::int_ceil(7, 3) == 3);
+    // verifies negative integer division rounds downward
+    static_assert(fdapde::int_floor(-7, 3) == -3);
+    // verifies absolute value accepts unsigned coefficients
+    static_assert(fdapde::abs(3u) == 3u);
+    // verifies strict stable comparison remains false at equality
+    static_assert(!fdapde::greater_than(2.0, 2.0) && !fdapde::less_than(2.0, 2.0));
+    // verifies the existing tolerance-based non-strict comparison convention
+    static_assert(!fdapde::greater_equal(2.0, 2.0) && !fdapde::less_equal(2.0, 2.0));
+    // verifies the nonnegative sign convention remains unchanged
+    static_assert(fdapde::sign(-2.0) == 0 && fdapde::sign(0.0) == 1);
+    // verifies the minimum signed exponent is handled without signed negation overflow
+    static_assert(fdapde::pow(1.0, std::numeric_limits<int>::min()) == 1.0);
+    // verifies wide exponents are not truncated to unsigned int
+    static_assert(fdapde::pow(-1.0, (1LL << 32) + 1) == -1.0);
+    // verifies negative powers evaluate the reciprocal
+    EXPECT_DOUBLE_EQ(fdapde::pow(2.0, -3), 0.125);
+    // compares a representative exponential with its standard library reference
+    EXPECT_NEAR(fdapde::exp(1.0), std::exp(1.0), 2e-6);
+    // checks stable softplus avoids overflow for large positive inputs
+    EXPECT_DOUBLE_EQ(fdapde::log1pexp(1000.0), 1000.0);
+}
+
+// verifies binary scaling preserves subnormals and supports every declared floating-point type
+TEST(NumericFoundation, BinaryScaling) {
+    // verifies the smallest positive double is representable during constant evaluation
+    static_assert(fdapde::ldexp(1.0, -1074) == std::numeric_limits<double>::denorm_min());
+    // verifies scaling a negative subnormal retains its sign and magnitude
+    static_assert(
+      fdapde::ldexp(-std::numeric_limits<double>::denorm_min(), 1) == -2 * std::numeric_limits<double>::denorm_min());
+    // verifies character-sized integer exponents retain the declared integer support
+    static_assert(fdapde::ldexp(0.75, char(3)) == 6.0);
+    // verifies float scaling does not depend on a binary64 bit_cast
+    static_assert(fdapde::ldexp(0.75f, 3) == 6.0f);
+    // verifies long double scaling uses its own format and precision
+    static_assert(fdapde::ldexp(0.75L, 3) == 6.0L);
+    // verifies maximum exponents are bounded before integer conversion
+    static_assert(
+      fdapde::ldexp(1.0, std::numeric_limits<unsigned long long>::max()) == std::numeric_limits<double>::infinity());
+    // verifies minimum exponents underflow without integer overflow
+    static_assert(fdapde::ldexp(1.0, std::numeric_limits<long long>::min()) == 0.0);
+    constexpr std::array inputs {0.5, 0.75, 1.0, 1.5, -1.5, std::numeric_limits<double>::max()};
+    constexpr std::array exponents {-1075, -1074, -1023, -3, 0, 3, 1023};
+    constexpr auto constant_results = [inputs, exponents] {
+        std::array<double, inputs.size() * exponents.size()> results {};
+        int i = 0;
+        for (double value : inputs)
+            for (int exponent : exponents) results[i++] = fdapde::ldexp(value, exponent);
+        return results;
+    }();
+    int i = 0;
+    for (double value : inputs) {
+        for (int exponent : exponents) {
+            SCOPED_TRACE(value);
+            SCOPED_TRACE(exponent);
+            // compares constant scaling with std::ldexp including ties at underflow
+            EXPECT_EQ(constant_results[i++], std::ldexp(value, exponent));
+            // compares runtime scaling with std::ldexp at the same boundaries
+            EXPECT_EQ(fdapde::ldexp(value, exponent), std::ldexp(value, exponent));
+        }
+    }
+    // verifies runtime scaling preserves negative zero
+    EXPECT_TRUE(std::signbit(fdapde::ldexp(-0.0, 8)));
+}

--- a/tests/utility/numeric.cpp
+++ b/tests/utility/numeric.cpp
@@ -1,0 +1,150 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/utility.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <limits>
+
+namespace {
+using lookup_types = std::tuple<int, double, char>;
+static_assert(fdapde::internals::index_of<int, lookup_types>::value == 0);
+static_assert(fdapde::internals::index_of<double, lookup_types>::value == 1);
+static_assert(fdapde::internals::index_of<char, lookup_types>::value == 2);
+
+constexpr double infinity = std::numeric_limits<double>::infinity();
+constexpr double not_a_number = std::numeric_limits<double>::quiet_NaN();
+static_assert(fdapde::sqrt(1e-20) > 0.99999999999999e-10 && fdapde::sqrt(1e-20) < 1.00000000000001e-10);
+static_assert(fdapde::sqrt(infinity) == infinity);
+static_assert(fdapde::sqrt(-1.0) != fdapde::sqrt(-1.0));
+static_assert(fdapde::sqrt(-infinity) != fdapde::sqrt(-infinity));
+static_assert(fdapde::sqrt(not_a_number) != fdapde::sqrt(not_a_number));
+static_assert(std::bit_cast<std::uint64_t>(fdapde::sqrt(-0.0)) == std::bit_cast<std::uint64_t>(-0.0));
+
+constexpr auto decompose(double value) {
+    int exponent = 0;
+    const double fraction = fdapde::frexp(value, exponent);
+    return std::pair {fraction, exponent};
+}
+static_assert(decompose(-8.0) == std::pair {-0.5, 4});
+static_assert(decompose(std::numeric_limits<double>::denorm_min()) ==
+              std::pair {0.5, std::numeric_limits<double>::min_exponent - std::numeric_limits<double>::digits + 1});
+static_assert(decompose(infinity) == std::pair {infinity, 0});
+static_assert(decompose(-infinity) == std::pair {-infinity, 0});
+static_assert(decompose(not_a_number).first != decompose(not_a_number).first);
+static_assert(decompose(not_a_number).second == 0);
+static_assert(std::bit_cast<std::uint64_t>(decompose(-0.0).first) == std::bit_cast<std::uint64_t>(-0.0));
+
+static_assert(fdapde::log(infinity) == infinity);
+static_assert(fdapde::log(0.0) == -infinity && fdapde::log(-0.0) == -infinity);
+static_assert(fdapde::log(-1.0) != fdapde::log(-1.0));
+static_assert(fdapde::log(-infinity) != fdapde::log(-infinity));
+static_assert(fdapde::log(not_a_number) != fdapde::log(not_a_number));
+static_assert(fdapde::log1p(infinity) == infinity);
+
+template <typename Scalar> void check_square_roots() {
+    constexpr std::array inputs {
+      Scalar(0), Scalar(1), Scalar(4), Scalar(1e-20), Scalar(1e20),
+      std::numeric_limits<Scalar>::min(), std::numeric_limits<Scalar>::denorm_min(),
+      std::numeric_limits<Scalar>::max()};
+    constexpr auto constant_results = [inputs] {
+        auto results = inputs;
+        for (auto& value : results) value = fdapde::sqrt(value);
+        return results;
+    }();
+    for (std::size_t i = 0; i < inputs.size(); ++i) {
+        SCOPED_TRACE(inputs[i]);
+        const Scalar expected = std::sqrt(inputs[i]);
+        if (inputs[i] == Scalar(0)) {
+            EXPECT_EQ(constant_results[i], expected);
+            EXPECT_EQ(fdapde::sqrt(inputs[i]), expected);
+        } else {
+            const Scalar tolerance = Scalar(8) * std::numeric_limits<Scalar>::epsilon();
+            EXPECT_LE(std::abs(constant_results[i] / expected - Scalar(1)), tolerance);
+            EXPECT_LE(std::abs(fdapde::sqrt(inputs[i]) / expected - Scalar(1)), tolerance);
+        }
+    }
+    EXPECT_TRUE(std::signbit(fdapde::sqrt(Scalar(-0.0))));
+    EXPECT_EQ(fdapde::sqrt(std::numeric_limits<Scalar>::infinity()), std::numeric_limits<Scalar>::infinity());
+    EXPECT_TRUE(std::isnan(fdapde::sqrt(Scalar(-1))));
+    EXPECT_TRUE(std::isnan(fdapde::sqrt(-std::numeric_limits<Scalar>::infinity())));
+    EXPECT_TRUE(std::isnan(fdapde::sqrt(std::numeric_limits<Scalar>::quiet_NaN())));
+}
+}   // namespace
+
+TEST(utility, square_root_preserves_scale_and_domain_in_runtime_and_constant_evaluation) {
+    check_square_roots<float>();
+    check_square_roots<double>();
+    check_square_roots<long double>();
+}
+
+TEST(utility, frexp_preserves_signed_values_and_exponents) {
+    constexpr std::array inputs {
+      0.0, -0.0, 1.0, -8.0, 0.75, -0.75,
+      std::numeric_limits<double>::min(), -std::numeric_limits<double>::min(),
+      std::numeric_limits<double>::denorm_min(), -std::numeric_limits<double>::denorm_min(),
+      std::numeric_limits<double>::max(), -std::numeric_limits<double>::max()};
+    constexpr auto constant_results = [inputs] {
+        std::array<std::pair<double, int>, inputs.size()> results {};
+        for (std::size_t i = 0; i < inputs.size(); ++i) results[i] = decompose(inputs[i]);
+        return results;
+    }();
+    for (std::size_t i = 0; i < inputs.size(); ++i) {
+        SCOPED_TRACE(inputs[i]);
+        int expected_exponent = 0;
+        const double expected_fraction = std::frexp(inputs[i], &expected_exponent);
+        for (const auto& result : {constant_results[i], decompose(inputs[i])}) {
+            EXPECT_EQ(result.first, expected_fraction);
+            EXPECT_EQ(result.second, expected_exponent);
+            EXPECT_EQ(std::signbit(result.first), std::signbit(expected_fraction));
+            EXPECT_EQ(std::ldexp(result.first, result.second), inputs[i]);
+        }
+    }
+    for (const double value : {infinity, -infinity, not_a_number}) {
+        const auto result = decompose(value);
+        EXPECT_EQ(result.second, 0);
+        if (std::isnan(value)) EXPECT_TRUE(std::isnan(result.first));
+        else EXPECT_EQ(result.first, value);
+    }
+}
+
+TEST(utility, logarithm_preserves_limits_and_finite_values) {
+    constexpr std::array inputs {
+      0.5, 1.0, 1.00000001, 2.0, 1e-20, 1e20, std::numeric_limits<double>::min(),
+      std::numeric_limits<double>::denorm_min(), std::numeric_limits<double>::max()};
+    constexpr auto constant_results = [inputs] {
+        auto results = inputs;
+        for (auto& value : results) value = fdapde::log(value);
+        return results;
+    }();
+    for (std::size_t i = 0; i < inputs.size(); ++i) {
+        SCOPED_TRACE(inputs[i]);
+        const double expected = std::log(inputs[i]);
+        // The retained finite logarithm is a polynomial approximation, not a correctly rounded implementation.
+        constexpr double tolerance = 1e-9;
+        EXPECT_NEAR(constant_results[i], expected, tolerance);
+        EXPECT_NEAR(fdapde::log(inputs[i]), expected, tolerance);
+    }
+    EXPECT_EQ(fdapde::log(infinity), infinity);
+    EXPECT_EQ(fdapde::log1p(infinity), infinity);
+    EXPECT_EQ(fdapde::log(0.0), -infinity);
+    EXPECT_EQ(fdapde::log(-0.0), -infinity);
+    EXPECT_TRUE(std::isnan(fdapde::log(-1.0)));
+    EXPECT_TRUE(std::isnan(fdapde::log(-infinity)));
+    EXPECT_TRUE(std::isnan(fdapde::log(not_a_number)));
+}

--- a/tests/utility/numeric.cpp
+++ b/tests/utility/numeric.cpp
@@ -22,45 +22,67 @@
 #include <limits>
 
 namespace {
-using lookup_types = std::tuple<int, double, char>;
-static_assert(fdapde::internals::index_of<int, lookup_types>::value == 0);
-static_assert(fdapde::internals::index_of<double, lookup_types>::value == 1);
-static_assert(fdapde::internals::index_of<char, lookup_types>::value == 2);
-
 constexpr double infinity = std::numeric_limits<double>::infinity();
 constexpr double not_a_number = std::numeric_limits<double>::quiet_NaN();
+// bounds the constexpr root near the analytic value 1e-10
 static_assert(fdapde::sqrt(1e-20) > 0.99999999999999e-10 && fdapde::sqrt(1e-20) < 1.00000000000001e-10);
+// preserves the positive infinite square root
 static_assert(fdapde::sqrt(infinity) == infinity);
+// returns NaN for the root of a negative finite value
 static_assert(fdapde::sqrt(-1.0) != fdapde::sqrt(-1.0));
+// returns NaN for the root of negative infinity
 static_assert(fdapde::sqrt(-infinity) != fdapde::sqrt(-infinity));
+// propagates a NaN input through the constexpr root
 static_assert(fdapde::sqrt(not_a_number) != fdapde::sqrt(not_a_number));
+// compares bits to verify the root retains negative zero
 static_assert(std::bit_cast<std::uint64_t>(fdapde::sqrt(-0.0)) == std::bit_cast<std::uint64_t>(-0.0));
 
+/// @brief returns the signed fraction and binary exponent of a value
 constexpr auto decompose(double value) {
     int exponent = 0;
     const double fraction = fdapde::frexp(value, exponent);
     return std::pair {fraction, exponent};
 }
+// decomposes negative eight into a negative fraction and exponent four
 static_assert(decompose(-8.0) == std::pair {-0.5, 4});
-static_assert(decompose(std::numeric_limits<double>::denorm_min()) ==
-              std::pair {0.5, std::numeric_limits<double>::min_exponent - std::numeric_limits<double>::digits + 1});
+// checks the fraction and exponent of the smallest positive subnormal
+static_assert(
+  decompose(std::numeric_limits<double>::denorm_min()) ==
+  std::pair {0.5, std::numeric_limits<double>::min_exponent - std::numeric_limits<double>::digits + 1});
+// preserves positive infinity with the documented zero exponent
 static_assert(decompose(infinity) == std::pair {infinity, 0});
+// preserves negative infinity with the documented zero exponent
 static_assert(decompose(-infinity) == std::pair {-infinity, 0});
+// propagates NaN in the decomposed fraction
 static_assert(decompose(not_a_number).first != decompose(not_a_number).first);
+// sets the exponent of a NaN input to zero
 static_assert(decompose(not_a_number).second == 0);
+// compares fraction bits to verify decomposition retains negative zero
 static_assert(std::bit_cast<std::uint64_t>(decompose(-0.0).first) == std::bit_cast<std::uint64_t>(-0.0));
 
+// preserves the positive infinite logarithmic limit
 static_assert(fdapde::log(infinity) == infinity);
+// maps both signed zeros to the negative infinite logarithmic limit
 static_assert(fdapde::log(0.0) == -infinity && fdapde::log(-0.0) == -infinity);
+// returns NaN for the logarithm of a negative finite value
 static_assert(fdapde::log(-1.0) != fdapde::log(-1.0));
+// returns NaN for the logarithm of negative infinity
 static_assert(fdapde::log(-infinity) != fdapde::log(-infinity));
+// propagates a NaN input through the constexpr logarithm
 static_assert(fdapde::log(not_a_number) != fdapde::log(not_a_number));
+// preserves the positive infinite limit through log1p
 static_assert(fdapde::log1p(infinity) == infinity);
 
+/// @brief compares runtime and constexpr roots against the standard library
 template <typename Scalar> void check_square_roots() {
     constexpr std::array inputs {
-      Scalar(0), Scalar(1), Scalar(4), Scalar(1e-20), Scalar(1e20),
-      std::numeric_limits<Scalar>::min(), std::numeric_limits<Scalar>::denorm_min(),
+      Scalar(0),
+      Scalar(1),
+      Scalar(4),
+      Scalar(1e-20),
+      Scalar(1e20),
+      std::numeric_limits<Scalar>::min(),
+      std::numeric_limits<Scalar>::denorm_min(),
       std::numeric_limits<Scalar>::max()};
     constexpr auto constant_results = [inputs] {
         auto results = inputs;
@@ -71,34 +93,53 @@ template <typename Scalar> void check_square_roots() {
         SCOPED_TRACE(inputs[i]);
         const Scalar expected = std::sqrt(inputs[i]);
         if (inputs[i] == Scalar(0)) {
+            // checks that constant evaluation preserves exact zero
             EXPECT_EQ(constant_results[i], expected);
+            // checks that runtime evaluation preserves exact zero
             EXPECT_EQ(fdapde::sqrt(inputs[i]), expected);
         } else {
             const Scalar tolerance = Scalar(8) * std::numeric_limits<Scalar>::epsilon();
+            // bounds the relative error of the constexpr root across the floating-point range
             EXPECT_LE(std::abs(constant_results[i] / expected - Scalar(1)), tolerance);
+            // bounds the runtime root error relative to the standard library result
             EXPECT_LE(std::abs(fdapde::sqrt(inputs[i]) / expected - Scalar(1)), tolerance);
         }
     }
+    // checks that the runtime root retains negative zero
     EXPECT_TRUE(std::signbit(fdapde::sqrt(Scalar(-0.0))));
+    // checks the positive infinite root
     EXPECT_EQ(fdapde::sqrt(std::numeric_limits<Scalar>::infinity()), std::numeric_limits<Scalar>::infinity());
+    // checks that a negative finite argument produces NaN
     EXPECT_TRUE(std::isnan(fdapde::sqrt(Scalar(-1))));
+    // checks that negative infinity is outside the real domain
     EXPECT_TRUE(std::isnan(fdapde::sqrt(-std::numeric_limits<Scalar>::infinity())));
+    // checks NaN propagation through the runtime root
     EXPECT_TRUE(std::isnan(fdapde::sqrt(std::numeric_limits<Scalar>::quiet_NaN())));
 }
 }   // namespace
 
+// verifies root scaling and special values for every supported floating-point type
 TEST(utility, square_root_preserves_scale_and_domain_in_runtime_and_constant_evaluation) {
     check_square_roots<float>();
     check_square_roots<double>();
     check_square_roots<long double>();
 }
 
+// verifies signed decomposition at zero, finite extremes and nonfinite values
 TEST(utility, frexp_preserves_signed_values_and_exponents) {
     constexpr std::array inputs {
-      0.0, -0.0, 1.0, -8.0, 0.75, -0.75,
-      std::numeric_limits<double>::min(), -std::numeric_limits<double>::min(),
-      std::numeric_limits<double>::denorm_min(), -std::numeric_limits<double>::denorm_min(),
-      std::numeric_limits<double>::max(), -std::numeric_limits<double>::max()};
+      0.0,
+      -0.0,
+      1.0,
+      -8.0,
+      0.75,
+      -0.75,
+      std::numeric_limits<double>::min(),
+      -std::numeric_limits<double>::min(),
+      std::numeric_limits<double>::denorm_min(),
+      -std::numeric_limits<double>::denorm_min(),
+      std::numeric_limits<double>::max(),
+      -std::numeric_limits<double>::max()};
     constexpr auto constant_results = [inputs] {
         std::array<std::pair<double, int>, inputs.size()> results {};
         for (std::size_t i = 0; i < inputs.size(); ++i) results[i] = decompose(inputs[i]);
@@ -109,24 +150,42 @@ TEST(utility, frexp_preserves_signed_values_and_exponents) {
         int expected_exponent = 0;
         const double expected_fraction = std::frexp(inputs[i], &expected_exponent);
         for (const auto& result : {constant_results[i], decompose(inputs[i])}) {
+            // compares the signed fraction with std::frexp
             EXPECT_EQ(result.first, expected_fraction);
+            // compares the exponent with std::frexp including subnormal inputs
             EXPECT_EQ(result.second, expected_exponent);
+            // checks the fraction sign separately so negative zero is covered
             EXPECT_EQ(std::signbit(result.first), std::signbit(expected_fraction));
+            // reconstructs the original input from the returned fraction and exponent
             EXPECT_EQ(std::ldexp(result.first, result.second), inputs[i]);
         }
     }
     for (const double value : {infinity, -infinity, not_a_number}) {
         const auto result = decompose(value);
+        // checks the documented zero exponent for nonfinite inputs
         EXPECT_EQ(result.second, 0);
-        if (std::isnan(value)) EXPECT_TRUE(std::isnan(result.first));
-        else EXPECT_EQ(result.first, value);
+        if (std::isnan(value)) {
+            // verifies a NaN fraction remains NaN
+            EXPECT_TRUE(std::isnan(result.first));
+        } else {
+            // verifies the sign of infinity is retained
+            EXPECT_EQ(result.first, value);
+        }
     }
 }
 
+// verifies logarithm limits and approximation error at representative finite scales
 TEST(utility, logarithm_preserves_limits_and_finite_values) {
     constexpr std::array inputs {
-      0.5, 1.0, 1.00000001, 2.0, 1e-20, 1e20, std::numeric_limits<double>::min(),
-      std::numeric_limits<double>::denorm_min(), std::numeric_limits<double>::max()};
+      0.5,
+      1.0,
+      1.00000001,
+      2.0,
+      1e-20,
+      1e20,
+      std::numeric_limits<double>::min(),
+      std::numeric_limits<double>::denorm_min(),
+      std::numeric_limits<double>::max()};
     constexpr auto constant_results = [inputs] {
         auto results = inputs;
         for (auto& value : results) value = fdapde::log(value);
@@ -135,16 +194,25 @@ TEST(utility, logarithm_preserves_limits_and_finite_values) {
     for (std::size_t i = 0; i < inputs.size(); ++i) {
         SCOPED_TRACE(inputs[i]);
         const double expected = std::log(inputs[i]);
-        // The retained finite logarithm is a polynomial approximation, not a correctly rounded implementation.
+        // the logarithm polynomial is checked with an absolute approximation tolerance
         constexpr double tolerance = 1e-9;
+        // bounds constexpr logarithm approximation error against std::log
         EXPECT_NEAR(constant_results[i], expected, tolerance);
+        // bounds runtime logarithm approximation error against std::log
         EXPECT_NEAR(fdapde::log(inputs[i]), expected, tolerance);
     }
+    // checks that logarithm maps positive infinity to positive infinity
     EXPECT_EQ(fdapde::log(infinity), infinity);
+    // checks that log1p inherits the positive infinite limit
     EXPECT_EQ(fdapde::log1p(infinity), infinity);
+    // checks the right-hand logarithmic limit at zero
     EXPECT_EQ(fdapde::log(0.0), -infinity);
+    // checks that signed zero has the same logarithmic limit
     EXPECT_EQ(fdapde::log(-0.0), -infinity);
+    // rejects negative finite logarithm inputs with NaN
     EXPECT_TRUE(std::isnan(fdapde::log(-1.0)));
+    // rejects negative infinity with NaN
     EXPECT_TRUE(std::isnan(fdapde::log(-infinity)));
+    // checks NaN propagation through the logarithm
     EXPECT_TRUE(std::isnan(fdapde::log(not_a_number)));
 }

--- a/tests/utility/numeric_callers.cpp
+++ b/tests/utility/numeric_callers.cpp
@@ -1,0 +1,57 @@
+// This file is part of fdaPDE, a C++ library for physics-informed
+// spatial and functional data analysis.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <fdaPDE/core.h>
+#include <gtest/gtest.h>
+
+// verifies the strict comparison helpers still support stable spatial range queries
+TEST(NumericCallers, KDTreeIncludesBoundaryPoints) {
+    Eigen::Matrix<double, 5, 2> points;
+    points << 0, 0, 1, 1, 2, 2, 3, 3, 4, 4;
+    fdapde::KDTree<2> tree(points);
+    auto result = tree.range_search({Eigen::Vector2d(1, 1), Eigen::Vector2d(3, 3)});
+    // compares the complete point-index set including both query boundaries
+    EXPECT_EQ(result, (std::unordered_set<int> {1, 2, 3}));
+}
+
+// verifies shared traits still recognize Eigen vectors and preserve stable expression nesting
+TEST(NumericCallers, EigenTraitsAndStableMatrixExpressions) {
+    // verifies Eigen column vectors retain vector-like dispatch
+    static_assert(fdapde::internals::is_vector_like_v<Eigen::VectorXd>);
+    // verifies Eigen matrices are not mistaken for vectors
+    static_assert(!fdapde::internals::is_vector_like_v<Eigen::MatrixXd>);
+    fdapde::Matrix<double, 2, 2> matrix(std::vector<double> {1, 2, 3, 4});
+    fdapde::Matrix<double, 2, 2> result = matrix + matrix;
+    // checks that the first coefficient is read through the original owning matrix
+    EXPECT_DOUBLE_EQ(result(0, 0), 2.0);
+    // checks the last coefficient survives expression assignment
+    EXPECT_DOUBLE_EQ(result(1, 1), 8.0);
+}
+
+// verifies finite-element assembly still reaches the shared combinatorial and expression utilities
+TEST(NumericCallers, LinearFiniteElementMass) {
+    fdapde::Triangulation<1, 1> domain(0.0, 1.0, 3);
+    fdapde::FeSpace space(domain, fdapde::P1<1>);
+    fdapde::TrialFunction f(space);
+    fdapde::TestFunction v(space);
+    auto mass = fdapde::integral(domain)(f * v).assemble();
+    // checks that the mass matrix includes each degree of freedom
+    EXPECT_EQ(mass.rows(), 3);
+    // checks the integral of the partition of unity over the unit interval
+    EXPECT_NEAR(mass.sum(), 1.0, 1e-12);
+    // compares the middle basis-function mass with the analytic P1 value
+    EXPECT_NEAR(mass.coeff(1, 1), 1.0 / 3.0, 1e-12);
+}


### PR DESCRIPTION
This PR fixes numeric errors in the scalar utilities and makes them usable in C++20 constant expressions. The fixes below are implemented and covered by passing regression tests.

**Fixed in this PR**

- `sqrt`: small positive inputs retain their scale instead of producing an inaccurate result.
- `log`: positive infinity produces positive infinity.
- `frexp`: binary decomposition preserves negative signs and handles subnormal inputs.
- `ldexp`: subnormal results are preserved, and the implementation supports its declared floating-point types. For example, `ldexp(1.0, -1074)` now returns the smallest positive `double` instead of zero; `ldexp(0.75f, 3)` now compiles and returns `6.0f`.
- Integer powers handle wide and minimum signed exponents. Scalar `min`/`max` use common-type promotion and reject unsupported operands.

The change also supplies shared expression nesting metadata and documents the numeric approximation limits. It does not replace the core matrix implementation. `exp` and finite `log` remain approximations; this PR does not claim correctly rounded results for all inputs.

**Verified successfully**

- 25/25 tests pass locally with AppleClang 21 Debug, GCC 15.2 Release and AppleClang ASan/UBSan; nine tests are added by this PR.
- Linux CI passes with GCC 14 and Clang.
- Runtime and constant-expression tests cover the corrected numeric cases. The public headers compile independently, and existing core consumer tests pass for Eigen dispatch, dense expressions, KD-tree boundary queries and P1 FEM mass assembly.

**Still unresolved outside this PR**

The separately tested `fdaPDE-cpp` revision `75af380` does not compile because it still calls `fdapde_assert` with one argument. Those calls must be migrated to the three-argument assertion API. This PR does not modify or fix them.

The same compilation errors were reproduced with both this PR's base and its final commit, so they are not introduced by the numeric changes. Consequently, the full `fdaPDE-cpp` model-layer tests have not been validated by this PR.
